### PR TITLE
Add new fields to the yaml file for live streaming

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -196,3 +196,10 @@ content:
   notifications:
     intro: "Stay up to date with GOV.UK"
     email_link: "Sign up to get emails when we change any coronavirus information on the GOV.UK website"
+  live_stream:
+    video: ""
+    # the date field must be entered as day/month/year for example 01/04/2020
+    date: ""
+    # the time field must be entered in 24hr format with a colon eg 17:00
+    time: ""
+    show_video: false


### PR DESCRIPTION
We are adding a new section to the page ref: [trello](https://trello.com/c/fYzEgmTP/116-add-the-ability-to-feature-the-govts-youtube-livestream-on-the-landing-page-and-turn-it-off-again)

We will need to add some validation to the date in collections publisher, but for now i've added comments to the yaml file for guidance.  