### PR TITLE
Add content for no cookies video placeholder

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -200,6 +200,12 @@ content:
     title: Live press conference
     video_url: https://www.youtube.com/watch?v=nB8MZaspQZw
     no_cookies_message: "Watch the live stream on YouTube"
+    no_cookies:
+      change_settings: "Change your cookie settings"
+      change_settings_link: "/help/cookies"
+      to_watch: "to watch the live stream"
+      or: "or"
+      watch_link_text: "Watch the live stream on YouTube"
     date: 31st March 2020
     time: 5:00pm
     show_video: false


### PR DESCRIPTION
- this includes the text currently displayed from "no_cookies_message", will leave both the old and the new in place for now in order to make this backwards compatible as we deploy it, will remove that field once the code changes are live in collections

Related PR: https://github.com/alphagov/collections/pull/1629

Trello card: https://trello.com/c/fYzEgmTP/116-add-the-ability-to-feature-the-govts-youtube-livestream-on-the-landing-page-and-turn-it-off-again