### PR TITLE
Add fields to support SpecialAnnouncement schema

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -209,3 +209,15 @@ content:
     date: 1st April 2020
     time: 5:00pm
     show_video: false
+  # https://schema.org/SpecialAnnouncement fields
+  special_announcement_schema:
+    category: https://www.wikidata.org/wiki/Q81068910
+    # date_posted: uses the content_item's public_updated_at property
+    disease_prevention_info_url: https://www.gov.uk/coronavirus
+    disease_spread_statistics_url: https://www.gov.uk/government/publications/covid-19-track-coronavirus-cases
+    # getting_tested_info_url: No appropriate URL available at present
+    news_updates_and_guidelines_url: https://www.gov.uk/coronavirus
+    public_transport_closures_info_url: https://www.gov.uk/guidance/coronavirus-covid-19-uk-transport-and-travel-advice
+    quarantine_guidelines_url: https://www.gov.uk/government/publications/coronavirus-outbreak-faqs-what-you-can-and-cant-do/coronavirus-outbreak-faqs-what-you-can-and-cant-do
+    school_closures_info_url: https://www.gov.uk/check-school-closure
+    travel_bans_url: https://www.gov.uk/guidance/travel-advice-novel-coronavirus


### PR DESCRIPTION
The fields added here correspond to the new fields in https://schema.org/SpecialAnnouncement
We can update them as necessary.

The category is the Wikidata page for the COVID-19 pandemic and is the advised
category stated on the https://schema.org/SpecialAnnouncement page.

https://trello.com/c/kZlkA3eD/126-add-specialannouncement-schema-to-the-landing-page