### PR TITLE
Add persistent link for Live stream

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -198,7 +198,7 @@ content:
     email_link: "Sign up to get emails when we change any coronavirus information on the GOV.UK website"
   live_stream:
     title: Live press conference
-    video_url: https://www.youtube.com/watch?v=t5y4jIrDCdM
+    video_url: https://www.youtube.com/embed/live_stream?channel=UC8o7mIMg3mmO9-dx3e2iFgw
     no_cookies_message: "Watch the live stream on YouTube"
     no_cookies:
       change_settings: "Change your cookie settings"


### PR DESCRIPTION
## What
It looks like we can use a persistent livestream URL for the daily press conferences, but we'll need to make some changes to the component to do this.

**Livestream URL**
https://www.youtube.com/embed/live_stream?channel=UC8o7mIMg3mmO9-dx3e2iFgw

## Why
This is saves us having to get a new livestream URL from No.10 everyday.

## Done when
We've switched the landing page to use the persistent livestream URL

https://trello.com/c/Ce9Lnkvs/127-add-support-for-a-persistent-livestream-url