### PR TITLE
Revert "Update date to 2nd April 2020"

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -206,9 +206,9 @@ content:
       to_watch: "to watch the live stream"
       or: "or"
       watch_link_text: "Watch the live stream on YouTube"
-    date: 2nd April 2020
+    date: 1st April 2020
     time: 5:00pm
-    show_video: true
+    show_video: false
   # https://schema.org/SpecialAnnouncement fields
   special_announcement_schema:
     category: https://www.wikidata.org/wiki/Q81068910


### PR DESCRIPTION
Reverts alphagov/govuk-coronavirus-content#24

Turning off until we confirm the time