### PR TITLE
Remove unneeded line

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -186,7 +186,6 @@ content:
   live_stream:
     title: Live press conference
     video_url: https://www.youtube.com/embed/live_stream?channel=UC8o7mIMg3mmO9-dx3e2iFgw
-    no_cookies_message: "Watch the live stream on YouTube"
     no_cookies:
       change_settings: "Change your cookie settings"
       change_settings_link: "/help/cookies"


### PR DESCRIPTION
- no_cookies_message was used prior to the enhancement to the video placeholder if users had not consented to cookies
- the new code for this uses all the text in no_cookies
- this was previously left in place to allow a change to be made without breaking the live site at any point

This can be merged only once https://github.com/alphagov/collections/pull/1629 has been deployed.