### PR TITLE
Split page title and content item title

### DIFF
--- a/content/coronavirus_business_page.yml
+++ b/content/coronavirus_business_page.yml
@@ -1,7 +1,7 @@
 content:
-  title: Business support
+  title: "Coronavirus (COVID-19): Business support"
   meta_description: "Get coronavirus (COVID-19) support for your business or if you’re self-employed, and find out how to keep your business and your employees safe"
-  page_header: "Business support"
+  page_title: "Business support"
   header_section:
     pretext: Coronavirus (COVID-19) support will be available to businesses
     list:


### PR DESCRIPTION
I've renamed the `page_header` property as it wasn't being used.

The `title` property is at present used for both the content item title and the h1 of the /coronavirus/business-support page.

The [h1 has the additional context of "Coronavirus (COVID-19)"](https://github.com/alphagov/collections/blob/828497f2502b26778585427d1da687845a69590a/app/controllers/coronavirus_landing_page_controller.rb#L26) which is not reflected in search results (either GOV.UK or Google) meaning that users won't recognise the page as being particularly relevant to them.

By adding the coronavirus prefix to the content item title, we give that extra context and help site search to rank the page more effectively.  We don't want to duplicate this on the page h1 though, so we name that separately. 

Matches the work in https://github.com/alphagov/collections/pull/1659