### PR TITLE
Add "tests" for well-formed YAML

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,11 @@
+name: YAML Validation
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-ruby@v1
+      with:
+        ruby-version: '2.6'
+    - run: ruby tests/well-formed-yaml.rb

--- a/tests/well-formed-yaml.rb
+++ b/tests/well-formed-yaml.rb
@@ -1,0 +1,15 @@
+#!/usr/bin/env ruby
+
+require "yaml"
+
+Dir.glob("#{__dir__}/../content/*.yml") do |filename|
+  begin
+    YAML.load_file(filename)
+  rescue StandardError => e
+    puts "Failed to load YAML for '#{File.basename(filename)}' - is it well formed?"
+    puts "Remember that YAML is fussy about characters like colons and quotes, so you might need to put some quotes around one of your values."
+    puts ""
+    puts "The error was: #{e.message}"
+    exit 1
+  end
+end


### PR DESCRIPTION
Add some very simple tests just to check that the YAML is basically well-formed.

When these fail, it looks like this:

https://travis-ci.com/github/alphagov/govuk-coronavirus-content/builds/159165202

This should hopefully catch silly mistakes like the one I fixed in https://github.com/alphagov/govuk-coronavirus-content/pull/61

If we wanted to do this "properly" we could probably validate the file against a JSON schema too, which would catch a whole case of other mistakes (like typos in keys, or missing `-`s in list items and so on).