### PR TITLE
Wednesday 8 April – release 2

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -169,7 +169,7 @@ content:
     text: "Additional guidance is available"
     links:
       - label: "Scotland"
-        url: https://www.gov.scot/coronavirus-covid-19/
+        url: /guidance/coronavirus-covid-19-information-for-individuals-and-businesses-in-scotland
       - label: "Wales"
         url: https://gov.wales/coronavirus
       - label: "Northern Ireland"


### PR DESCRIPTION
Changes to the landing page in this PR:

1. Replace link to Scottish Government website with a link to the UK Government Scotland page, which summarises both the UK and Scottish governments’ response to the virus.