### PR TITLE
Enable live stream for 11th April 2020

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -204,9 +204,9 @@ content:
       url: https://www.youtube.com/user/Number10gov/videos
       previous_videos_text: View past coronavirus press conferences on YouTube
       next_conference_text: The next live press conference will be shown here
-    date: 10th April 2020
+    date: 11th April 2020
     time:
-    show_video: false
+    show_video: true
   # https://schema.org/SpecialAnnouncement fields
   special_announcement_schema:
     category: https://www.wikidata.org/wiki/Q81068910


### PR DESCRIPTION
Enables the live stream for the daily press briefing on 11th April 2020.

Not to be deployed until ten minutes before the briefing begins.