### PR TITLE
Disable live stream for 11th April 2020

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -207,7 +207,7 @@ content:
       next_conference_text: The next live press conference will be shown here
     date: 11th April 2020
     time:
-    show_video: true
+    show_video: false
   # https://schema.org/SpecialAnnouncement fields
   special_announcement_schema:
     category: https://www.wikidata.org/wiki/Q81068910


### PR DESCRIPTION
Disables the press briefing live stream from the coronavirus landing page.