### PR TITLE
Enable live stream for 13th April 2020

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -207,9 +207,9 @@ content:
       url: https://www.youtube.com/user/Number10gov/videos
       previous_videos_text: View past coronavirus press conferences on YouTube
       next_conference_text: The next live press conference will be shown here
-    date: 12th April 2020
-    time: 4:00pm
-    show_video: false
+    date: 13th April 2020
+    time: 5:00pm
+    show_video: true
   # https://schema.org/SpecialAnnouncement fields
   special_announcement_schema:
     category: https://www.wikidata.org/wiki/Q81068910


### PR DESCRIPTION
Enables the press briefing live stream for 13th April 2020.

Not to be merged until 16:45.