### PR TITLE
Disable live stream for 13th April 2020

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -209,7 +209,7 @@ content:
       next_conference_text: The next live press conference will be shown here
     date: 13th April 2020
     time: 5:00pm
-    show_video: true
+    show_video: false
   # https://schema.org/SpecialAnnouncement fields
   special_announcement_schema:
     category: https://www.wikidata.org/wiki/Q81068910


### PR DESCRIPTION
Disables the press conference live video stream.

Not to be merged until the press briefing has finished.