### PR TITLE
Add content for coronavirus landing page Find Help box

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -30,6 +30,12 @@ content:
     call_to_action:
       title: Check the NHS website if you have symptoms
       href: https://www.nhs.uk/conditions/coronavirus-covid-19/symptoms-and-what-to-do/
+  find_help:
+    heading: "Find help if you're struggling because of coronavirus"
+    paragraph: "For example, with paying bills, being out of work, or taking care of your mental health."
+    link:
+      href: "/find-coronavirus-support"
+      text: "Find help"
   explainer_title:
   explainer_text:
   sections:

--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -31,7 +31,7 @@ content:
       title: Check the NHS website if you have symptoms
       href: https://www.nhs.uk/conditions/coronavirus-covid-19/symptoms-and-what-to-do/
   find_help:
-    heading: "Find help if you're struggling because of coronavirus"
+    heading: "Find help if you’re struggling because of coronavirus"
     paragraph: "For example, with paying bills, being out of work, or taking care of your mental health."
     link:
       href: "/find-coronavirus-support"


### PR DESCRIPTION
Add content for new covid homepage "find help" box.

https://github.com/alphagov/collections/pull/1680
https://trello.com/c/52XhjjAr

