### PR TITLE
Enable livestream 17th April

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -216,8 +216,8 @@ content:
       url: https://www.youtube.com/user/Number10gov/videos
       previous_videos_text: View past coronavirus press conferences on YouTube
       next_conference_text: The next live press conference will be shown here
-    date: 16th April 2020
-    show_video: false
+    date: 17th April 2020
+    show_video: true
   live_stream_enabled: false
   # https://schema.org/SpecialAnnouncement fields
   special_announcement_schema:


### PR DESCRIPTION
As I get it from @hannako in #109, we'll still use the `show_video` key for the day.