### PR TITLE
New announcement added

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -16,8 +16,8 @@ content:
       text: "Read more about what you can and cannot&nbsp;do"
   announcements_label: Announcements
   announcements:
-    - text: £750 million extra funding for frontline charities
-      href: /government/news/chancellor-sets-out-extra-750-million-coronavirus-funding-for-frontline-charities
+    - text: Free laptops to help vulnerable and disadvantaged young people
+      href: /government/news/new-major-package-to-support-online-learning
     - text: Tell the NHS about your current experience of coronavirus
       href: https://www.nhs.uk/coronavirus-status-checker
     - text: UK plan ensures personal protective equipment (PPE) is delivered to workers who need it most


### PR DESCRIPTION
New announcement: Free laptops to help vulnerable and disadvantaged young people 

This replaces the existing announcement: £750 million extra funding for frontline charities.