### PR TITLE
Remove find help links

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -57,8 +57,6 @@ content:
               url: /government/publications/coronavirus-covid-19-providing-unpaid-care
             - label: Support for victims of domestic violence
               url: /government/publications/coronavirus-covid-19-and-domestic-abuse/coronavirus-covid-19-support-for-victims-of-domestic-abuse
-            - label: Find out what you can do if you’re struggling because of coronavirus
-              url: /find-coronavirus-support
     - title: Health and wellbeing
       sub_sections:
         - title:
@@ -83,8 +81,6 @@ content:
               url: /guidance/coronavirus-covid-19-what-to-do-if-youre-self-employed-and-getting-less-work-or-no-work
             - label: Already getting benefits – how they’re affected
               url: /guidance/coronavirus-covid-19-what-to-do-if-youre-already-getting-benefits
-            - label: Find out what you can do if you’re struggling because of coronavirus
-              url: /find-coronavirus-support
     - title: Businesses and self-employed people
       sub_sections:
         - title:


### PR DESCRIPTION
Removed:
'Find out what you can do if you’re struggling because of coronavirus'

From: 
Protect yourself and others
Work, financial support, and money