### PR TITLE
Add content to support arrow link componentisation

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -14,6 +14,8 @@ content:
     link:
       href: /government/publications/coronavirus-outbreak-faqs-what-you-can-and-cant-do/coronavirus-outbreak-faqs-what-you-can-and-cant-do
       text: "Read more about what you can and cannot&nbsp;do"
+      link_text: "Read more about what you can and cannot"
+      link_nowrap_text: "do"
   announcements_label: Announcements
   announcements:
     - text: You can now claim for employee's wages through the Coronavirus Job Retention Scheme

--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -14,8 +14,8 @@ content:
     link:
       href: /government/publications/coronavirus-outbreak-faqs-what-you-can-and-cant-do/coronavirus-outbreak-faqs-what-you-can-and-cant-do
       text: "Read more about what you can and cannot&nbsp;do"
-      link_text: "Read more about what you can and cannot"
-      link_nowrap_text: "do"
+      link_text: "Read more about what you can and"
+      link_nowrap_text: "cannot do"
   announcements_label: Announcements
   announcements:
     - text: You can now claim for employee's wages through the Coronavirus Job Retention Scheme


### PR DESCRIPTION
This change is to support the componentisation of the highlight arrow
link that is used in a few different variants across the corona virus
content pages.

Currently we are using an nbsp character to prevent the last word
wrapping to the next line on smaller screens for the page header version
of this element.

As part of our work to componentise the highlight/arrow link, we have
adopted a different approach to preventing undesired word wrapping for
the component.

The text containing an nbsp character will become redundant and is to be
removed once the componentisation work has safely made it to the live
site.

Relevant Trello card: https://trello.com/c/dxdWqUST