### PR TITLE
Update NHS URL 23/04/20

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -37,7 +37,7 @@ content:
       - a new, continuous cough
     call_to_action:
       title: Check the NHS website if you have symptoms
-      href: https://www.nhs.uk/conditions/coronavirus-covid-19/symptoms-and-what-to-do/
+      href: https://www.nhs.uk/conditions/coronavirus-covid-19/check-if-you-have-coronavirus-symptoms/
   find_help:
     heading: "Find help if you’re struggling because of coronavirus"
     paragraph: "For example, with paying bills, being out of work, or taking care of your mental health."


### PR DESCRIPTION
URL in NHS call-out box was redirecting to new NHS URL. Updated link so redirect not needed.