### PR TITLE
New link added to 'Volunteering' section

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -172,6 +172,8 @@ content:
       sub_sections:
         - title:
           list:
+            - label: How to volunteer 
+              url: /volunteering/coronavirus-volunteering
             - label: Offer the help of your business
               url: /coronavirus-support-from-business
             - label: How to help others safely


### PR DESCRIPTION
Link text: how to volunteer
URL: /volunteering/coronavirus-volunteering