### PR TITLE
23 April change to announcements and testing

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -24,9 +24,9 @@ content:
     - text: Tell the NHS about your current experience of coronavirus
       href: https://www.nhs.uk/coronavirus-status-checker
       published_text: Published 5 April 2020
-    - text: UK plan ensures personal protective equipment (PPE) is delivered to workers who need it most
-      href: /government/news/government-sets-out-plan-for-national-effort-on-ppe
-      published_text: Published 10 April 2020
+    - text: Guidance on testing for essential workers
+      href: /guidance/coronavirus-covid-19-getting-tested
+      published_text: Published 15 April 2020
   see_all_announcements_link:
     text: See all announcements
     href: "/search/news-and-communications?topical_events%5B%5D=coronavirus-covid-19-uk-government-response"
@@ -69,7 +69,7 @@ content:
       sub_sections:
         - title:
           list:
-            - label: Testing for frontline workers
+            - label: Guidance on testing for essential workers
               url: /guidance/coronavirus-covid-19-getting-tested
     - title: Health and wellbeing
       sub_sections:


### PR DESCRIPTION
1. in announcements CHANGED: 

- text: UK plan ensures personal protective equipment (PPE) is delivered to workers who need it most
      href: /government/news/government-sets-out-plan-for-national-effort-on-ppe
      published_text: Published 10 April 2020

TO:

- text: Guidance on testing for essential workers
      href: /guidance/coronavirus-covid-19-getting-tested
      published_text: Published 15 April 2020

This is in lieu of a news story from No 10 (if it arrives before 10pm we can change again)

2. In Testing for coronavirus (COVID-19) CHANGED:

Testing for frontline workers

TO

Guidance on testing for essential workers

(same URL)