### PR TITLE
23 April 2020: change to announcements

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -24,9 +24,9 @@ content:
     - text: Tell the NHS about your current experience of coronavirus
       href: https://www.nhs.uk/coronavirus-status-checker
       published_text: Published 5 April 2020
-    - text: Guidance on testing for essential workers
-      href: /guidance/coronavirus-covid-19-getting-tested
-      published_text: Published 15 April 2020
+    - text: Coronavirus (COVID-19) testing extended to all essential workers in England who have symptoms
+      href: /government/news/coronavirus-testing-extended-to-all-essential-workers-in-england-who-have-symptoms
+      published_text: Published 23 April 2020
   see_all_announcements_link:
     text: See all announcements
     href: "/search/news-and-communications?topical_events%5B%5D=coronavirus-covid-19-uk-government-response"


### PR DESCRIPTION
CHANGED

- text: Guidance on testing for essential workers
      href: /guidance/coronavirus-covid-19-getting-tested
    published_text: Published 15 April 2020

TO

- text: Coronavirus (COVID-19) testing extended to all essential workers in England who have symptoms
      href: /government/news/coronavirus-testing-extended-to-all-essential-workers-in-england-who-have-symptoms
      published_text: Published 23 April 2020