### PR TITLE
23 April 2020 added links to Testing section

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -71,6 +71,10 @@ content:
           list:
             - label: Guidance on testing for essential workers
               url: /guidance/coronavirus-covid-19-getting-tested
+            - label: Apply for a test if you're an essential worker
+              url: https://self-referral.test-for-coronavirus.service.gov.uk/
+            - label: Book a test if you have a verification code
+              url: https://test-for-coronavirus.service.gov.uk/appointment
     - title: Health and wellbeing
       sub_sections:
         - title:

--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -71,7 +71,7 @@ content:
           list:
             - label: Guidance on testing for essential workers
               url: /guidance/coronavirus-covid-19-getting-tested
-            - label: Apply for a test if you're an essential worker
+            - label: Apply for a test if you’re an essential worker
               url: https://self-referral.test-for-coronavirus.service.gov.uk/
             - label: Book a test if you have a verification code
               url: https://test-for-coronavirus.service.gov.uk/appointment


### PR DESCRIPTION
Added:

- label: Apply for a test if you're an essential worker
url: https://self-referral.test-for-coronavirus.service.gov.uk/
- label: Book a test if you have a verification code
url: https://test-for-coronavirus.service.gov.uk/appointment