### PR TITLE
Add content for COVID homepage accordion update

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -46,6 +46,7 @@ content:
       text: "Find help"
   explainer_title:
   explainer_text:
+  sections_heading: "Guidance and support"
   sections:
     - title: Protect yourself and others from coronavirus
       sub_sections:
@@ -216,6 +217,15 @@ content:
               url: /government/publications/covid-19-track-coronavirus-cases
             - label: Latest number of coronavirus cases in the UK
               url: /guidance/coronavirus-covid-19-information-for-the-public
+  additional_country_guidance:
+    text: "Additional guidance for"
+    links:
+      - label: "Scotland"
+        url: /guidance/coronavirus-covid-19-information-for-individuals-and-businesses-in-scotland
+      - label: "Wales"
+        url: https://gov.wales/coronavirus
+      - label: "Northern Ireland"
+        url: https://www.nidirect.gov.uk/campaigns/coronavirus-covid-19
   country_section:
     header: "If you live in Scotland, Wales or Northern Ireland"
     text: "Additional guidance is available"


### PR DESCRIPTION
Added content for the accordion section heading and country guidance section
below accordion.

![Screenshot_2020-04-23_at_18 42 30](https://user-images.githubusercontent.com/7116819/80195216-6bd76400-8613-11ea-9377-d7132432bbc0.png)


TODO: Make sure to remove the `country_section` field from the YML file when it's no longer being used 

TRELLO: https://trello.com/c/WyQxHLMh