### PR TITLE
Post arrow link componentisation cleanup

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -13,7 +13,6 @@ content:
     pretext-2: You can spread the virus even if you don’t have symptoms.
     link:
       href: /government/publications/coronavirus-outbreak-faqs-what-you-can-and-cant-do/coronavirus-outbreak-faqs-what-you-can-and-cant-do
-      text: "Read more about what you can and cannot&nbsp;do"
       link_text: "Read more about what you can and"
       link_nowrap_text: "cannot do"
   announcements_label: Announcements


### PR DESCRIPTION
This is a follow up task for https://trello.com/c/dxdWqUST

The work done to componentise the arrow link has made this content field redundant as we switched from `text` to `link_text` on the frontend (see https://github.com/alphagov/collections/pull/1688/files#diff-1e885d202901bd89ef38bb987e543327)