### PR TITLE
Update question tool URL

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -262,7 +262,7 @@ content:
       next_conference_text: The next live press conference will be shown here
     ask_a_question_visible: false
     ask_a_question_text: Ask a question at the next press conference
-    ask_a_question_link: https://www.gov.uk/ask
+    ask_a_question_link: /ask
     date_text: Live streamed
     date: 24th April 2020
     show_video: false

--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -260,8 +260,9 @@ content:
       url: https://www.youtube.com/user/Number10gov/videos
       previous_videos_text: Watch all press conferences on YouTube
       next_conference_text: The next live press conference will be shown here
+    ask_a_question_visible: false
     ask_a_question_text: Ask a question at the next press conference
-    ask_a_question_link: https://www.gov.uk
+    ask_a_question_link: https://www.gov.uk/ask
     date_text: Live streamed
     date: 24th April 2020
     show_video: false


### PR DESCRIPTION
This is now the correct URL.

To show the link we'll need to change `ask_a_question_visible: false` to `ask_a_question_visible: true`

https://github.com/alphagov/collections/pull/1699 must be deployed for this to have any effect