### PR TITLE
Update all information section

### DIFF
--- a/content/coronavirus_business_page.yml
+++ b/content/coronavirus_business_page.yml
@@ -154,12 +154,11 @@ content:
               url: /coronavirus-support-from-business
   topic_section:
     header: "All coronavirus business support information on GOV.UK"
-    text: "Browse information related to coronavirus"
     links:
-      - label: "News"
-        url: /search/news-and-communications?level_one_taxon=495afdb6-47be-4df1-8b38-91c8adb1eefc&topical_events%5B%5D=coronavirus-covid-19-uk-government-response&order=updated-newest
       - label: "Guidance"
         url: /search/all?level_one_taxon=495afdb6-47be-4df1-8b38-91c8adb1eefc&topical_events%5B%5D=coronavirus-covid-19-uk-government-response&order=updated-newest
+      - label: "News"
+        url: /search/news-and-communications?level_one_taxon=495afdb6-47be-4df1-8b38-91c8adb1eefc&topical_events%5B%5D=coronavirus-covid-19-uk-government-response&order=updated-newest
   notifications:
     intro: "Stay up to date with GOV.UK"
     email_link: "Sign up to get emails when we change any coronavirus information on the GOV.UK website"

--- a/content/coronavirus_education_page.yml
+++ b/content/coronavirus_education_page.yml
@@ -83,12 +83,11 @@ content:
               url: /government/publications/coronavirus-covid-19-maintaining-further-education-provision
   topic_section:
     header: "All coronavirus education and childcare information on GOV.UK"
-    text: "Browse information related to coronavirus"
     links:
-      - label: "News"
-        url: /search/news-and-communications?level_one_taxon=c58fdadd-7743-46d6-9629-90bb3ccc4ef0&topical_events%5B%5D=coronavirus-covid-19-uk-government-response&order=updated-newest
       - label: "Guidance"
         url: /search/all?level_one_taxon=c58fdadd-7743-46d6-9629-90bb3ccc4ef0&topical_events%5B%5D=coronavirus-covid-19-uk-government-response&order=updated-newest
+      - label: "News"
+        url: /search/news-and-communications?level_one_taxon=c58fdadd-7743-46d6-9629-90bb3ccc4ef0&topical_events%5B%5D=coronavirus-covid-19-uk-government-response&order=updated-newest
   notifications:
     intro: "Stay up to date with GOV.UK"
     email_link: "Sign up to get emails when we change any coronavirus information on the GOV.UK website"

--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -236,13 +236,12 @@ content:
       - label: "Northern Ireland"
         url: https://www.nidirect.gov.uk/campaigns/coronavirus-covid-19
   topic_section:
-    header: "All coronavirus (COVID-19) information"
-    text: "Browse information related to coronavirus"
+    header: "All coronavirus information on GOV.UK"
     links:
-      - label: "News"
-        url: /search/news-and-communications?topical_events%5B%5D=coronavirus-covid-19-uk-government-response
       - label: "Guidance"
         url: /search/all?topical_events%5B%5D=coronavirus-covid-19-uk-government-response&order=updated-newest
+      - label: "News"
+        url: /search/news-and-communications?topical_events%5B%5D=coronavirus-covid-19-uk-government-response
   notifications:
     intro: "Stay up to date with GOV.UK"
     email_link: "Sign up to get emails when we change any coronavirus information on the GOV.UK website"


### PR DESCRIPTION
**This represents a breaking change, do not merge until a [this PR](https://github.com/alphagov/collections/pull/1700) is deployed**

Landing page

- change title
- remove description beneath title
- change order of the two links

Business and Education hubs

- keep title (was already based on the landing page)
- remove descriptions
- change order of the two links

Trello card: https://trello.com/c/Ypqv4HGc/217-update-all-information-section-with-new-simpler-design