### PR TITLE
Update live press conference stream (Apr 28 2020)

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -220,8 +220,8 @@ content:
     email_link: "Sign up to get emails when we change any coronavirus information on the GOV.UK website"
   live_stream:
     title: Press conference
-    video_url: https://www.youtube.com/watch?v=JCi87m622oE
-    date: 27th April 2020
+    video_url: https://www.youtube.com/watch?v=Tccer6BFKDw
+    date: 28th April 2020
     date_text: Live streamed
     no_cookies:
       change_settings: "Change your cookie settings"


### PR DESCRIPTION
This follows the documentation for adding a new video to /coronavirus on GOV.UK.