### PR TITLE
28 April 2020: change to test section

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -75,7 +75,7 @@ content:
               url: https://self-referral.test-for-coronavirus.service.gov.uk/
             - label: Book a coronavirus (COVID-19) test if you have a verification code
               url: https://test-for-coronavirus.service.gov.uk/appointment
-            - label: Apply for a coronavirus (COVID-19) test if you have a clinical referral
+            - label: Apply for a coronavirus (COVID-19) test if you have a clinical referral, are aged 65 or over, or must currently travel to work
               url: https://self-referral.test-for-coronavirus.service.gov.uk/test-type
     - title: Health and wellbeing
       sub_sections:


### PR DESCRIPTION
CHANGED
label: Apply for a coronavirus (COVID-19) test if you have a clinical referral
              url: https://self-referral.test-for-coronavirus.service.gov.uk/test-type

TO
label: Apply for a coronavirus (COVID-19) test if you have a clinical referral, are aged 65 or over, or must currently travel to work
              url: https://self-referral.test-for-coronavirus.service.gov.uk/test-type