### PR TITLE
Update coronavirus_landing_page.yml

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -65,17 +65,17 @@ content:
               url: /government/collections/coronavirus-covid-19-social-care-guidance#guidance-for-unpaid-carers
             - label: Support for victims of domestic violence
               url: /government/publications/coronavirus-covid-19-and-domestic-abuse/coronavirus-covid-19-support-for-victims-of-domestic-abuse
-    - title: Testing for coronavirus (COVID-19)
+    - title: Testing for coronavirus
       sub_sections:
         - title:
           list:
             - label: Guidance on testing for essential workers
               url: /guidance/coronavirus-covid-19-getting-tested
-            - label: Apply for a coronavirus (COVID-19) test if you’re an essential worker
+            - label: Apply for a coronavirus test if you’re an essential worker
               url: https://self-referral.test-for-coronavirus.service.gov.uk/
-            - label: Book a coronavirus (COVID-19) test if you have a verification code
+            - label: Book a coronavirus test if you have a verification code
               url: https://test-for-coronavirus.service.gov.uk/appointment
-            - label: Apply for a coronavirus (COVID-19) test if you have a clinical referral, are aged 65 or over, or must currently travel to work
+            - label: Apply for a coronavirus test if you have a clinical referral, are aged 65 or over and have symptoms, or must currently travel to work and have symptoms
               url: https://self-referral.test-for-coronavirus.service.gov.uk/test-type
     - title: Health and wellbeing
       sub_sections:


### PR DESCRIPTION
1. CHANGED
- label: Apply for a coronavirus test if you have a clinical referral
              url: https://self-referral.test-for-coronavirus.service.gov.uk/test-type

TO
- label: Apply for a coronavirus test if you have a clinical referral, are aged 65 or over and have symptoms, or must currently travel to work and have symptoms
              url: https://self-referral.test-for-coronavirus.service.gov.uk/test-type

2. REMOVED {COVID-19) from testing link texts

[To be published: TBC]