### PR TITLE
Housing section - swapping link order

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -121,10 +121,10 @@ content:
       sub_sections:
         - title:
           list:
-           - label: Planning inspections
-             url: /guidance/coronavirus-covid-19-planning-inspectorate-guidance
            - label: "Renting: guidance for landlords, tenants and local authorities"
              url: /government/publications/covid-19-and-renting-guidance-for-landlords-tenants-and-local-authorities
+           - label: Planning inspections
+             url: /guidance/coronavirus-covid-19-planning-inspectorate-guidance
     - title: Driving and transport in the UK
       sub_sections:
         - title:


### PR DESCRIPTION
Update to the order of the links in the housing section. Done on 29 April 2020. 