### PR TITLE
Remove 'th' from date under press conference

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -221,7 +221,7 @@ content:
   live_stream:
     title: Press conference
     video_url: https://www.youtube.com/watch?v=Tccer6BFKDw
-    date: 28th April 2020
+    date: 28 April 2020
     date_text: Live streamed
     no_cookies:
       change_settings: "Change your cookie settings"


### PR DESCRIPTION
Make date GOV.UK style. Done on 29 April 2020. 