### PR TITLE
Add safeguarding link to Education and Childcare page

### DIFF
--- a/content/coronavirus_education_page.yml
+++ b/content/coronavirus_education_page.yml
@@ -33,6 +33,8 @@ content:
               url: /government/publications/coronavirus-covid-19-guidance-on-isolation-for-residential-educational-settings
             - label: Supporting vulnerable children
               url: /government/publications/coronavirus-covid-19-guidance-on-vulnerable-children-and-young-people
+            - label: Interim safeguarding guidance
+              url: /government/publications/covid-19-safeguarding-in-schools-colleges-and-other-providers/coronavirus-covid-19-safeguarding-in-schools-colleges-and-other-providers 
             - label: SEND risk assessment guidance
               url: /government/publications/coronavirus-covid-19-send-risk-assessment-guidance
     - title: Closures, exams and managing a school or early years setting


### PR DESCRIPTION
Safeguarding link added to pupil wellbeing and safety section

### What
<!-- eg _Changes to accordian links on the Coronavirus business page_ -->

### Why
<!-- eg _Request from BEIS_ -->

### :warning: Only merge this pull request if you are happy for the changes to be made live :warning:
