### PR TITLE
Follow redirect to hand-hygiene/resources

### DIFF
--- a/content/coronavirus_business_page.yml
+++ b/content/coronavirus_business_page.yml
@@ -87,7 +87,7 @@ content:
             - label: Cleaning your workplace safely
               url: /government/publications/covid-19-decontamination-in-non-healthcare-settings
             - label: Handwashing advice posters
-              url: https://campaignresources.phe.gov.uk/resources/campaigns/101/resources/5016
+              url: https://coronavirusresources.phe.gov.uk/hand-hygiene/resources/
             - label: Rules that have been relaxed to help businesses during the coronavirus pandemic
               url: /guidance/rules-that-have-been-relaxed-to-help-businesses-during-the-coronavirus-pandemic
             - label: Construction sites and safe working


### PR DESCRIPTION
:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

What
----

At the moment

https://campaignresources.phe.gov.uk/resources/campaigns/101/resources/5016

is redirecting to

https://coronavirusresources.phe.gov.uk/hand-hygiene/resources/

So we may as well update our link to point straight there.

Why
---

It will save users visiting this link a hop, which will ever-so-slightly
speed things up for them.