### PR TITLE
Udpate header section

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -2,17 +2,16 @@ content:
   title: "Coronavirus (COVID-19): guidance and support"
   meta_description: "Find information on coronavirus, including guidance, support, announcements and statistics."
   page_header: "Coronavirus (COVID&#8209;19)"
-  stay_at_home:
-    pretext: Stay alert
+  header_section:
+    title: Stay alert
+    pretext-1: "We can all help control the virus if we all stay alert. This means you must:"
+    pretext-2: Self-isolate if you or anyone in your household has symptoms.
     list:
       - stay at home as much as possible
       - work from home if you can
       - limit contact with other people
       - keep your distance if you go out (2 metres apart where possible)
       - wash your hands regularly
-  guidance:
-    pretext-1: "We can all help control the virus if we all stay alert. This means you must:"
-    pretext-2: Self-isolate if you or anyone in your household has symptoms.
     link:
       href: /government/publications/coronavirus-outbreak-faqs-what-you-can-and-cant-do/coronavirus-outbreak-faqs-what-you-can-and-cant-do
       link_text: "Read more about what you can and"

--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -2,6 +2,23 @@ content:
   title: "Coronavirus (COVID-19): guidance and support"
   meta_description: "Find information on coronavirus, including guidance, support, announcements and statistics."
   page_header: "Coronavirus (COVID&#8209;19)"
+  # ---- this section can be deleted once the pr for collections to read from header_section has been deployed ----#
+  stay_at_home:
+    pretext: Stay alert
+    list:
+      - stay at home as much as possible
+      - work from home if you can
+      - limit contact with other people
+      - keep your distance if you go out (2 metres apart where possible)
+      - wash your hands regularly
+  guidance:
+    pretext-1: "We can all help control the virus if we all stay alert. This means you must:"
+    pretext-2: Self-isolate if you or anyone in your household has symptoms.
+    link:
+      href: /government/publications/coronavirus-outbreak-faqs-what-you-can-and-cant-do/coronavirus-outbreak-faqs-what-you-can-and-cant-do
+      link_text: "Read more about what you can and"
+      link_nowrap_text: "cannot do"
+  # ----- end ------- #
   header_section:
     title: Stay alert
     pretext-1: "We can all help control the virus if we all stay alert. This means you must:"


### PR DESCRIPTION
- The `stay_at_home` hash in the /coronavirus content item has become a bit confusing. To simplify things I've combined `stay_at_home` and `guidance` into a single `header_section`.

- We need the old keys to be present in the yaml for now, so that when we publish the content item, collections will still be able to render the landing page. Once the content item containing the new header section is live, we can then [safely deploy the changes to collections](https://github.com/alphagov/collections/pull/1726) which is expecting there to be a `header_section` key, and remove the old keys from the yaml.

[card](https://trello.com/c/m0HMJsP2/270-simplify-the-structure-of-the-content-item-header-section-of-coronavirus-landing-page)