### PR TITLE
Remove old heading content

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -2,23 +2,6 @@ content:
   title: "Coronavirus (COVID-19): guidance and support"
   meta_description: "Find information on coronavirus, including guidance, support, announcements and statistics."
   page_header: "Coronavirus (COVID&#8209;19)"
-  # ---- this section can be deleted once the pr for collections to read from header_section has been deployed ----#
-  stay_at_home:
-    pretext: Stay alert
-    list:
-      - stay at home as much as possible
-      - work from home if you can
-      - limit contact with other people
-      - keep your distance if you go out (2 metres apart where possible)
-      - wash your hands regularly
-  guidance:
-    pretext-1: "We can all help control the virus if we all stay alert. This means you must:"
-    pretext-2: Self-isolate if you or anyone in your household has symptoms.
-    link:
-      href: /government/publications/coronavirus-outbreak-faqs-what-you-can-and-cant-do/coronavirus-outbreak-faqs-what-you-can-and-cant-do
-      link_text: "Read more about what you can and"
-      link_nowrap_text: "cannot do"
-  # ----- end ------- #
   header_section:
     title: Stay alert
     pretext-1: "We can all help control the virus if we all stay alert. This means you must:"


### PR DESCRIPTION
This content was re-organised into the `header_section` to make it easier to understand. They were previously split into two bits, but presented in the same section, which made reviewing changes to this file confusing.

:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

