### PR TITLE
Unblock publishing

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -277,3 +277,6 @@ content:
     quarantine_guidelines_url: https://www.gov.uk/government/publications/coronavirus-outbreak-faqs-what-you-can-and-cant-do/coronavirus-outbreak-faqs-what-you-can-and-cant-do
     school_closures_info_url: https://www.gov.uk/check-school-closure
     travel_bans_url: https://www.gov.uk/guidance/travel-advice-novel-coronavirus
+  # The following sections are here temporarily to unblock publishing
+  stay_at_home: "DO NOT USE THIS"
+  guidance: "DO NOT USE THIS"


### PR DESCRIPTION
Collections publisher has [a check that the stay_at_home and guidance keys](https://github.com/alphagov/collections-publisher/blob/master/app/controllers/coronavirus_controller.rb#L159-L160)
exist.  We removed them just now as part of a refactor of the content item. 

Adding them back in temporarily to unblock publishing.

I'll make the change to the publishing app, but this is a slower process.
