### PR TITLE
Add new statistics section

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -226,7 +226,7 @@ content:
       - label: "Northern Ireland"
         url: https://www.nidirect.gov.uk/campaigns/coronavirus-covid-19
   statistics_section:
-    header: "Statistics"
+    header: Statistics
     links:
       - label: Track coronavirus cases in the UK
         url: /government/publications/covid-19-track-coronavirus-cases

--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -216,14 +216,6 @@ content:
               url: /bereavement-support-payment
             - label: Check if you can get help with funeral costs
               url: /funeral-payments
-    - title: Coronavirus (COVID-19) cases in the UK
-      sub_sections:
-        - title:
-          list:
-            - label: Track coronavirus cases in the UK
-              url: /government/publications/covid-19-track-coronavirus-cases
-            - label: Latest number of coronavirus cases in the UK
-              url: /guidance/coronavirus-covid-19-information-for-the-public
   additional_country_guidance:
     text: "Additional guidance for"
     links:
@@ -233,6 +225,13 @@ content:
         url: https://gov.wales/coronavirus
       - label: "Northern Ireland"
         url: https://www.nidirect.gov.uk/campaigns/coronavirus-covid-19
+  statistics_section:
+    header: "Statistics"
+    links:
+      - label: Track coronavirus cases in the UK
+        url: /government/publications/covid-19-track-coronavirus-cases
+      - label: Latest number of coronavirus cases in the UK
+        url: /guidance/coronavirus-covid-19-information-for-the-public
   topic_section:
     header: "All coronavirus information on GOV.UK"
     links:


### PR DESCRIPTION
### What
- Remove "Coronavirus (COVID-19) cases in the UK" section from the
accordion
- Create new `statistics_section` content which for the time being is
  replicating the aforementioned accordion section links

### Why
We're moving the dashboard stuff out of the accordion because it's not guidance.

https://trello.com/c/bjPJsGNf