### PR TITLE
[DO NOT MERGE] Removes stats data from accordion

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -218,14 +218,6 @@ content:
               url: /bereavement-support-payment
             - label: Check if you can get help with funeral costs
               url: /funeral-payments
-    - title: Coronavirus (COVID-19) cases in the UK
-      sub_sections:
-        - title:
-          list:
-            - label: Track coronavirus cases in the UK
-              url: /government/publications/covid-19-track-coronavirus-cases
-            - label: Latest number of coronavirus cases in the UK
-              url: /guidance/coronavirus-covid-19-information-for-the-public
   additional_country_guidance:
     text: "Additional guidance for"
     links:


### PR DESCRIPTION
Only merge this in after #229 has been published 

We are taking the statistics links out of the accordion and into their own separate section below the livestream.
This removes the accordion section to prevent content duplication.