### PR TITLE
272 - Add validation tests to the coronavirus content repo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,5 @@
 source "https://rubygems.org"
 
 gem "rspec"
+gem "govuk_schemas"
+gem 'jsonnet'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,17 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     diff-lcs (1.3)
+    govuk_schemas (4.0.0)
+      json-schema (~> 2.8.0)
+    json-schema (2.8.1)
+      addressable (>= 2.4)
+    jsonnet (0.3.0)
+      mini_portile2 (>= 2.2.0)
+    mini_portile2 (2.5.0)
+    public_suffix (4.0.5)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
@@ -20,6 +30,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  govuk_schemas
+  jsonnet
   rspec
 
 BUNDLED WITH

--- a/content/coronavirus_education_page.yml
+++ b/content/coronavirus_education_page.yml
@@ -34,7 +34,7 @@ content:
             - label: Supporting vulnerable children
               url: /government/publications/coronavirus-covid-19-guidance-on-vulnerable-children-and-young-people
             - label: Interim safeguarding guidance
-              url: /government/publications/covid-19-safeguarding-in-schools-colleges-and-other-providers/coronavirus-covid-19-safeguarding-in-schools-colleges-and-other-providers 
+              url: /government/publications/covid-19-safeguarding-in-schools-colleges-and-other-providers/coronavirus-covid-19-safeguarding-in-schools-colleges-and-other-providers
             - label: SEND risk assessment guidance
               url: /government/publications/coronavirus-covid-19-send-risk-assessment-guidance
     - title: Closures, exams and managing a school or early years setting

--- a/schema/coronavirus_hub_page.jsonnet
+++ b/schema/coronavirus_hub_page.jsonnet
@@ -1,0 +1,16 @@
+{
+  type: 'object',
+  required: ['content'],
+  properties: {
+    content: {
+      type: 'object',
+      required: [
+        'title',
+        'header_section',
+        'sections',
+        'topic_section',
+        'notifications'
+      ]
+    }
+  }
+}

--- a/schema/coronavirus_landing_page.jsonnet
+++ b/schema/coronavirus_landing_page.jsonnet
@@ -1,0 +1,20 @@
+{
+  type: 'object',
+  required: ['content'],
+  properties: {
+    content: {
+      type: 'object',
+      required: [
+        'title',
+        'meta_description',
+        'header_section',
+        'announcements_label',
+        'announcements',
+        'nhs_banner',
+        'sections',
+        'topic_section',
+        'notifications'
+      ]
+    }
+  }
+}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+require 'support/yaml_matchers'
+
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true

--- a/spec/support/yaml_matchers.rb
+++ b/spec/support/yaml_matchers.rb
@@ -1,4 +1,5 @@
 require 'rspec/expectations'
+require 'json-schema'
 
 RSpec::Matchers.define :load_yaml_file_without_error do |expected|
   match do |actual|
@@ -20,4 +21,17 @@ RSpec::Matchers.define :load_yaml_file_without_error do |expected|
       #{@error.message}"
     MESSAGE
   end
+end
+
+RSpec::Matchers.define :validate_yaml_in do |expected|
+  match do |actual|
+    @error = nil
+    begin
+      JSON::Validator.validate!(actual, expected)
+    rescue JSON::Schema::ValidationError => e
+      @error = e
+    end
+    expect(@error).to be_nil
+  end
+  failure_message { |actual| @error.message }
 end

--- a/spec/support/yaml_matchers.rb
+++ b/spec/support/yaml_matchers.rb
@@ -1,0 +1,23 @@
+require 'rspec/expectations'
+
+RSpec::Matchers.define :load_yaml_file_without_error do |expected|
+  match do |actual|
+    @error = nil
+    begin
+      YAML.load_file(actual)
+    rescue StandardError => e
+      @error = e
+    end
+    expect(@error).to be_nil
+  end
+  failure_message do |actual|
+    basename = File.basename(actual)
+    <<~MESSAGE
+    Failed to load YAML for '#{basename}' - is it well formed?
+    Remember that YAML is fussy about characters like colons and quotes, so you might need to put some quotes around one of your values.
+
+    The error was:
+      #{@error.message}"
+    MESSAGE
+  end
+end

--- a/spec/well_formed_yaml_spec.rb
+++ b/spec/well_formed_yaml_spec.rb
@@ -1,12 +1,23 @@
 #!/usr/bin/env ruby
 
-require "yaml"
+require 'yaml'
+require 'jsonnet'
 RSpec.describe 'Content YAML files' do
   Dir.glob("#{__dir__}/../content/*.yml") do |filename|
     basename = File.basename(filename)
     describe basename do
-      it 'should be able to load the YAML content without error' do
+
+      let(:page_type) { basename =~ /coronavirus_landing_page/ ? :landing : :hub }
+      let(:schema) do
+        file_path = File.expand_path("../schema/coronavirus_#{page_type}_page.jsonnet", __dir__)
+        Jsonnet.load(file_path)
+      end
+      let(:yaml) { YAML.load_file(filename) }
+
+      it 'can be loaded and matches schema' do
+        # Running both expectations together as if first fails the second will fail with the same error
         expect(filename).to load_yaml_file_without_error
+        expect(schema).to validate_yaml_in(yaml)
       end
     end
   end

--- a/spec/well_formed_yaml_spec.rb
+++ b/spec/well_formed_yaml_spec.rb
@@ -1,25 +1,13 @@
 #!/usr/bin/env ruby
 
 require "yaml"
-
-Dir.glob("#{__dir__}/../content/*.yml") do |filename|
-  basename = File.basename(filename)
-  RSpec.describe basename do
-    it "should be able to load the YAML content without error" do
-      error = nil
-      begin
-        YAML.load_file(filename)
-      rescue StandardError => e
-        error = e
+RSpec.describe 'Content YAML files' do
+  Dir.glob("#{__dir__}/../content/*.yml") do |filename|
+    basename = File.basename(filename)
+    describe basename do
+      it 'should be able to load the YAML content without error' do
+        expect(filename).to load_yaml_file_without_error
       end
-      expect(e).to be_nil, lambda {
-        <<~MESSAGE
-        Failed to load YAML for '#{basename}' - is it well formed?
-        Remember that YAML is fussy about characters like colons and quotes, so you might need to put some quotes around one of your values.
-
-        The error was: #{error.message}"
-        MESSAGE
-      }
     end
   end
 end

--- a/spec/well_formed_yaml_spec.rb
+++ b/spec/well_formed_yaml_spec.rb
@@ -6,18 +6,55 @@ RSpec.describe 'Content YAML files' do
   Dir.glob("#{__dir__}/../content/*.yml") do |filename|
     basename = File.basename(filename)
     describe basename do
-
       let(:page_type) { basename =~ /coronavirus_landing_page/ ? :landing : :hub }
-      let(:schema) do
-        file_path = File.expand_path("../schema/coronavirus_#{page_type}_page.jsonnet", __dir__)
-        Jsonnet.load(file_path)
-      end
+      let(:schema_path) { File.expand_path("../schema/coronavirus_#{page_type}_page.jsonnet", __dir__) }
+      let(:schema) { Jsonnet.load(schema_path) }
       let(:yaml) { YAML.load_file(filename) }
 
       it 'can be loaded and matches schema' do
         # Running both expectations together as if first fails the second will fail with the same error
         expect(filename).to load_yaml_file_without_error
         expect(schema).to validate_yaml_in(yaml)
+      end
+
+      context 'with schema mismatch' do
+        let(:schema) do
+          {
+            type: 'object',
+            required: ['content'],
+            properties: {
+              content: {
+                type: 'object',
+                required: [
+                  'unknown_content'
+                ]
+              }
+            }
+          }
+        end
+
+        it 'does not validate YAML' do
+          expect(schema).not_to validate_yaml_in(yaml)
+        end
+      end
+    end
+  end
+
+  context 'non-matching YAML' do
+    Dir.glob("#{__dir__}/../schema/*.jsonnet") do |schema_path|
+      context "with #{File.basename(schema_path)}" do
+        let(:schema) { Jsonnet.load(schema_path) }
+        let(:yaml) do
+          {
+            'content' => {
+              'foo_bar' => 'unknown content'
+            }
+          }
+        end
+
+        it 'does not validate YAML' do
+          expect(schema).not_to validate_yaml_in(yaml)
+        end
       end
     end
   end


### PR DESCRIPTION
:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

# What

- Updates the existing test that the YAML file can be loaded so that the error messages don't include the code to construct the error messages.
- Add basic schema which are used to make (at the moment) simple checks of the YAML content

# Why
We want to move this validation closer to where publishers are working so that we can catch errors more quickly. At present it is possible to merge a file that cannot be published due to the validation in the publishing app.

## Notes
Currently failure messages output like this example:
```
2) YAML file coronavirus_business_page.yml should be able to load the YAML content without error
     Failure/Error:
               expect(e).to be_nil, lambda {
                 <<~MESSAGE
                 Failed to load YAML for '#{basename}' - is it well formed?
                 Remember that YAML is fussy about characters like colons and quotes, so you might need to put some quotes around one of your values.
       
                 The error was: #{error.message}"
                 MESSAGE
               }
     
       Failed to load YAML for 'coronavirus_business_page.yml' - is it well formed?
       Remember that YAML is fussy about characters like colons and quotes, so you might need to put some quotes around one of your values.
     
       The error was: (/home/rob/web/govuk/govuk-coronavirus-content/spec/../content/coronavirus_business_page.yml): did not find expected '-' indicator while parsing a block collection at line 23 column 9"
     # ./spec/well_formed_yaml_spec.rb:45:in `block (4 levels) in <top (required)>'
```

With this change a similar error outputs:
```
1) Content YAML files coronavirus_education_page.yml can be loaded and matches schema
     Failure/Error: expect(filename).to load_yaml_file_without_error
     
       Failed to load YAML for 'coronavirus_education_page.yml' - is it well formed?
       Remember that YAML is fussy about characters like colons and quotes, so you might need to put some quotes around one of your values.
     
       The error was:
         (/home/rob/web/govuk/govuk-coronavirus-content/spec/../content/coronavirus_education_page.yml): mapping values are not allowed in this context at line 13 column 21"
     # ./spec/well_formed_yaml_spec.rb:18:in `block (4 levels) in <top (required)>'
```

A schema error looks like this:
```
1) Content YAML files coronavirus_education_page.yml can be loaded and matches schema
     Failure/Error: expect(schema).to validate_yaml_in(yaml)
       The property '#/content' did not contain a required property of 'title'
     # ./spec/well_formed_yaml_spec.rb:20:in `block (4 levels) in <top (required)>'
```