### PR TITLE
Risk level content link href

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -39,7 +39,7 @@ content:
     # for instance, if our paragraph is "Find information on coronavirus", and we want the word "coronavirus" to be bold, we would set bold_text: coronavirus
     bold_text: Level X of 5
     link:
-      href: /
+      href: /risk-level
       text: Read more about COVID-19 alert levels
   nhs_banner:
     heading: "Do not leave home if you or someone you live with has either:"

--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -144,9 +144,9 @@ content:
         - title:
           list:
            - label: "Renting: guidance for landlords, tenants and local authorities"
-             url: /government/publications/covid-19-and-renting-guidance-for-landlords-tenants-and-local-authorities           
+             url: /government/publications/covid-19-and-renting-guidance-for-landlords-tenants-and-local-authorities
            - label: "Moving homes during the coronavirus outbreak"
-             url: /guidance/government-advice-on-home-moving-during-the-coronavirus-covid-19-outbreak                
+             url: /guidance/government-advice-on-home-moving-during-the-coronavirus-covid-19-outbreak
            - label: Planning inspections
              url: /guidance/coronavirus-covid-19-planning-inspectorate-guidance
     - title: Driving and transport in the UK


### PR DESCRIPTION
Add a href to the link for testing.
Publishing this won't change anything on the live site as we're not using this content item value anywhere yet. 
Need the link to have a href to get visual sign off for this adjacent PR on the heroku deploy https://github.com/alphagov/collections/pull/1732

_The risk level stuff is all dummy content for now which is Good and Expected._
