### PR TITLE
Link to Guidance for managing a funeral

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -236,6 +236,8 @@ content:
               url: /bereavement-support-payment
             - label: Check if you can get help with funeral costs
               url: /funeral-payments
+            - label: Guidance for managing a funeral
+              url: /government/publications/covid-19-guidance-for-managing-a-funeral-during-the-coronavirus-pandemic/covid-19-guidance-for-managing-a-funeral-during-the-coronavirus-pandemic
   additional_country_guidance:
     text: "Additional guidance for"
     links:


### PR DESCRIPTION
**NOTE: This change has not been reviewed by anyone in a decision making position for the landing page - at this point it's just a suggestion from Richard.**

:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

# What

Currently the guidance on how many people can attend a funeral, and what the rules for managing them are is a bit tricky to find. I found it by going through:

* https://www.gov.uk/coronavirus
* https://www.gov.uk/government/publications/coronavirus-outbreak-faqs-what-you-can-and-cant-do/coronavirus-outbreak-faqs-what-you-can-and-cant-do
* `1.` Public spaces / outdoor activities / exercise
* `1.11` Is there a limit on the number of people attending funerals?
* https://www.gov.uk/government/publications/covid-19-guidance-for-managing-a-funeral-during-the-coronavirus-pandemic
* https://www.gov.uk/government/publications/covid-19-guidance-for-managing-a-funeral-during-the-coronavirus-pandemic/covid-19-guidance-for-managing-a-funeral-during-the-coronavirus-pandemic

# Why

Richard thinks this guidance should be a bit more prominent, as it looks like it's the canonical source of "can I go to this person's funeral" advice.
