### PR TITLE
Update links to search and email subscriptions

### DIFF
--- a/content/coronavirus_business_page.yml
+++ b/content/coronavirus_business_page.yml
@@ -23,14 +23,14 @@ content:
         - title:
           list:
             - label: Find financial support for your business
-              url: /government/collections/financial-support-for-businesses-during-coronavirus-covid-19     
+              url: /government/collections/financial-support-for-businesses-during-coronavirus-covid-19
             - label: Find out what support your business representative organisation (BRO) offers
               url: /guidance/coronavirus-support-from-business-representative-organisations-and-trade-associations
             - label: Coronavirus support for business from outside government
               url: /guidance/coronavirus-support-for-business-from-outside-government
             - label: Additional government resources to support your business during coronavirus disruptions
               url: /guidance/additional-government-resources-to-support-your-business-during-coronavirus-disruptions
-            - label: Find out how other businesses have used government support  
+            - label: Find out how other businesses have used government support
               url: https://businesssupport.blog.gov.uk/
             - label: Support for UK businesses trading internationally
               url: https://www.gov.uk/government/publications/coronavirus-covid-19-guidance-for-uk-businesses/coronavirus-covid-19-guidance-for-uk-businesses-trading-internationally
@@ -65,7 +65,7 @@ content:
     - title: How to run your business safely
       sub_sections:
         - title:
-          list:              
+          list:
             - label: Find out how to make your workplace COVID-secure
               url: /workingsafely
             - label: How to carry out a COVID-19 risk asssessment
@@ -84,9 +84,10 @@ content:
     header: "All coronavirus business support information on GOV.UK"
     links:
       - label: "Guidance"
-        url: /search/all?level_one_taxon=495afdb6-47be-4df1-8b38-91c8adb1eefc&topical_events%5B%5D=coronavirus-covid-19-uk-government-response&order=updated-newest
+        url: "/search/all?level_one_taxon=5b7b9532-a775-4bd2-a3aa-6ce380184b6c&level_two_taxon=65666cdf-b177-4d79-9687-b9c32805e450"
       - label: "News"
-        url: /search/news-and-communications?level_one_taxon=495afdb6-47be-4df1-8b38-91c8adb1eefc&topical_events%5B%5D=coronavirus-covid-19-uk-government-response&order=updated-newest
+        url: "/search/news-and-communications?parent=/coronavirus-taxon/businesses-and-self-employed-people&topic=65666cdf-b177-4d79-9687-b9c32805e450&order=updated-newest"
   notifications:
     intro: "Stay up to date with GOV.UK"
-    email_link: "Sign up to get emails when we change any coronavirus information on the GOV.UK website"
+    email_link: "Sign up to get emails when we add new coronavirus business support information"
+    email_url: "/email-signup?topic=/coronavirus-taxon/businesses-and-self-employed-people"

--- a/content/coronavirus_education_page.yml
+++ b/content/coronavirus_education_page.yml
@@ -89,9 +89,10 @@ content:
     header: "All coronavirus education and childcare information on GOV.UK"
     links:
       - label: "Guidance"
-        url: /search/all?level_one_taxon=c58fdadd-7743-46d6-9629-90bb3ccc4ef0&topical_events%5B%5D=coronavirus-covid-19-uk-government-response&order=updated-newest
+        url: "/search/all?level_one_taxon=5b7b9532-a775-4bd2-a3aa-6ce380184b6c&level_two_taxon=272308f4-05c8-4d0d-abc7-b7c2e3ccd249&order=most-viewed"
       - label: "News"
-        url: /search/news-and-communications?level_one_taxon=c58fdadd-7743-46d6-9629-90bb3ccc4ef0&topical_events%5B%5D=coronavirus-covid-19-uk-government-response&order=updated-newest
+        url: "/search/news-and-communications?parent=/coronavirus-taxon/education-and-childcare&topic=272308f4-05c8-4d0d-abc7-b7c2e3ccd249&order=updated-newest"
   notifications:
     intro: "Stay up to date with GOV.UK"
-    email_link: "Sign up to get emails when we change any coronavirus information on the GOV.UK website"
+    email_link: "Sign up to get emails when we add new coronavirus education and childcare information"
+    email_url: "/email-signup?topic=/coronavirus-taxon/education-and-childcare"

--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -29,7 +29,7 @@ content:
       published_text: Published 10 May 2020
   see_all_announcements_link:
     text: See all announcements
-    href: "/search/news-and-communications?topical_events%5B%5D=coronavirus-covid-19-uk-government-response"
+    href: "/search/news-and-communications?parent=/coronavirus-taxon&topic=5b7b9532-a775-4bd2-a3aa-6ce380184b6c&order=updated-newest"
   risk_level:
     #set show_risk_level_section to true to display the risk/alert level section on the landing page
     show_risk_level_section: true
@@ -82,9 +82,9 @@ content:
       sub_sections:
         - title:
           list:
-            - label: Guidance on testing for essential workers and care homes 
+            - label: Guidance on testing for essential workers and care homes
               url: /guidance/coronavirus-covid-19-getting-tested
-            - label: Apply for a test if you have coronavirus symptoms 
+            - label: Apply for a test if you have coronavirus symptoms
               url: https://www.nhs.uk/conditions/coronavirus-covid-19/testing-for-coronavirus/ask-for-a-test-to-check-if-you-have-coronavirus/
             - label: Apply for a test if you are an essential worker
               url: /apply-coronavirus-test
@@ -258,12 +258,13 @@ content:
     header: "All coronavirus information on GOV.UK"
     links:
       - label: "Guidance"
-        url: /search/all?topical_events%5B%5D=coronavirus-covid-19-uk-government-response&order=updated-newest
+        url: "/search/all?level_one_taxon=5b7b9532-a775-4bd2-a3aa-6ce380184b6c"
       - label: "News"
-        url: /search/news-and-communications?topical_events%5B%5D=coronavirus-covid-19-uk-government-response
+        url: "/search/news-and-communications?parent=/coronavirus-taxon&topic=5b7b9532-a775-4bd2-a3aa-6ce380184b6c&order=updated-newest"
   notifications:
     intro: "Stay up to date with GOV.UK"
     email_link: "Sign up to get emails when we change any coronavirus information on the GOV.UK website"
+    email_url: "/email-signup?topic=/coronavirus-taxon"
   live_stream:
     title: Press conferences and speeches
     date_text: Broadcast


### PR DESCRIPTION
These links show content based on the taxonomy, so allow better filtering.

Email signup links aren't shown on the hub pages yet, but we can prepare
the content item in advance.

:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

The links can be tested 👇

## Business page
 
[Guidance search](https://www.gov.uk/search/all?level_one_taxon=5b7b9532-a775-4bd2-a3aa-6ce380184b6c&level_two_taxon=65666cdf-b177-4d79-9687-b9c32805e450)
[News search](https://www.gov.uk/search/news-and-communications?parent=/coronavirus-taxon/businesses-and-self-employed-people&topic=65666cdf-b177-4d79-9687-b9c32805e450&order=updated-newest)
[Email signup](https://www.gov.uk/email-signup?topic=/coronavirus-taxon/businesses-and-self-employed-people)

## Education page 

[Guidance search](https://www.gov.uk/search/all?level_one_taxon=5b7b9532-a775-4bd2-a3aa-6ce380184b6c&level_two_taxon=272308f4-05c8-4d0d-abc7-b7c2e3ccd249&order=most-viewed)
[News search](https://www.gov.uk/search/news-and-communications?parent=/coronavirus-taxon/education-and-childcare&topic=272308f4-05c8-4d0d-abc7-b7c2e3ccd249&order=updated-newest)
[Email signup](https://www.gov.uk/email-signup?topic=/coronavirus-taxon/education-and-childcare)

## Coronavirus page

[Guidance search](https://www.gov.uk/search/all?level_one_taxon=5b7b9532-a775-4bd2-a3aa-6ce380184b6c)
[News search](https://www.gov.uk/search/news-and-communications?parent=/coronavirus-taxon&topic=5b7b9532-a775-4bd2-a3aa-6ce380184b6c&order=updated-newest)
[Email signup](https://www.gov.uk/email-signup?topic=/coronavirus-taxon)


https://trello.com/c/AFkthgYZ/294-add-email-signup-to-the-hubs
https://trello.com/c/QzUfkSZB/222-epic-switchover-the-landing-page-and-hubs-to-use-the-taxonomy