### PR TITLE
Remove help NHS link

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -202,8 +202,6 @@ content:
               url: /guidance/help-the-government-increase-coronavirus-covid-19-testing-capacity
             - label: Help tackle false information spreading online
               url: https://sharechecklist.gov.uk/
-            - label: Help the NHS respond to coronavirus
-              url: https://www.nhs.uk/conditions/coronavirus-covid-19/help-the-nhs-respond-to-coronavirus/
     - title: Healthcare workers, carers and care settings
       sub_sections:
         - title:


### PR DESCRIPTION
Section: Volunteering and offering help

REMOVED: 
Help the NHS respond to coronavirus

Why: 
NHS no longer have this page
https://govuk.zendesk.com/agent/tickets/4079859

:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

# What
<!-- eg Changes to accordion links on the Coronavirus business page -->

# Why
<!-- eg Request from BEIS -->
