### PR TITLE
Switch risk level section off

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -32,7 +32,7 @@ content:
     href: "/search/news-and-communications?topical_events%5B%5D=coronavirus-covid-19-uk-government-response"
   risk_level:
     #set show_risk_level_section to true to display the risk/alert level section on the landing page
-    show_risk_level_section: true
+    show_risk_level_section: false
     heading: COVID-19 alert level
     paragraph: Level X of 5 – there is something happening
     # bold_text should be the portion of the paragraph you would like to make bold.
@@ -82,9 +82,9 @@ content:
       sub_sections:
         - title:
           list:
-            - label: Guidance on testing for essential workers and care homes 
+            - label: Guidance on testing for essential workers and care homes
               url: /guidance/coronavirus-covid-19-getting-tested
-            - label: Apply for a test if you have coronavirus symptoms 
+            - label: Apply for a test if you have coronavirus symptoms
               url: https://www.nhs.uk/conditions/coronavirus-covid-19/testing-for-coronavirus/ask-for-a-test-to-check-if-you-have-coronavirus/
             - label: Apply for a test if you are an essential worker
               url: /apply-coronavirus-test


### PR DESCRIPTION
I had set `show_risk_level_section` to `true` for testing.

This switches it back off so that this piece of work can be merged in to collections master  👉🏼https://github.com/alphagov/collections/pull/1732

-----

https://trello.com/c/zPDbYoE3

-----


