### PR TITLE
Changed link text on the education hub

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -140,7 +140,7 @@ content:
       sub_sections:
         - title:
           list:
-            - label: How universities, nurseries, schools and colleges are working
+            - label: Guidance for teachers, leaders, carers, parents and students
               url: /coronavirus/education-and-childcare
               featured_link: true
               description: "Coronavirus (COVID-19) information for parents, schools, colleges and universities: closures, exams, learning, health and wellbeing."


### PR DESCRIPTION
See accordion: School closures, education and childcare

Link text changed to: Guidance for teachers, leaders, carers, parents and students

:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

# What
<!-- eg Changes to accordion links on the Coronavirus business page -->

# Why
<!-- eg Request from BEIS -->
