### PR TITLE
Update search links

### DIFF
--- a/content/coronavirus_business_page.yml
+++ b/content/coronavirus_business_page.yml
@@ -84,9 +84,9 @@ content:
     header: "All coronavirus business support information on GOV.UK"
     links:
       - label: "Guidance"
-        url: "/search/all?level_one_taxon=5b7b9532-a775-4bd2-a3aa-6ce380184b6c&level_two_taxon=65666cdf-b177-4d79-9687-b9c32805e450"
+        url: "/search/all?level_one_taxon=5b7b9532-a775-4bd2-a3aa-6ce380184b6c&level_two_taxon=65666cdf-b177-4d79-9687-b9c32805e450&content_purpose_supergroup%5B%5D=guidance_and_regulation&order=most-viewed"
       - label: "News"
-        url: "/search/news-and-communications?parent=/coronavirus-taxon/businesses-and-self-employed-people&topic=65666cdf-b177-4d79-9687-b9c32805e450&order=updated-newest"
+        url: "/search/all?level_one_taxon=5b7b9532-a775-4bd2-a3aa-6ce380184b6c&level_two_taxon=65666cdf-b177-4d79-9687-b9c32805e450&content_purpose_supergroup%5B%5D=news_and_communications&order=updated-newest"
   notifications:
     intro: "Stay up to date with GOV.UK"
     email_link: "Sign up to get emails when we add new coronavirus business support information"

--- a/content/coronavirus_education_page.yml
+++ b/content/coronavirus_education_page.yml
@@ -106,9 +106,9 @@ content:
     header: "All coronavirus education and childcare information on GOV.UK"
     links:
       - label: "Guidance"
-        url: "/search/all?level_one_taxon=5b7b9532-a775-4bd2-a3aa-6ce380184b6c&level_two_taxon=272308f4-05c8-4d0d-abc7-b7c2e3ccd249&order=most-viewed"
+        url: "/search/all?level_one_taxon=5b7b9532-a775-4bd2-a3aa-6ce380184b6c&level_two_taxon=272308f4-05c8-4d0d-abc7-b7c2e3ccd249&content_purpose_supergroup%5B%5D=guidance_and_regulation&order=most-viewed"
       - label: "News"
-        url: "/search/news-and-communications?parent=/coronavirus-taxon/education-and-childcare&topic=272308f4-05c8-4d0d-abc7-b7c2e3ccd249&order=updated-newest"
+        url: "/search/all?level_one_taxon=5b7b9532-a775-4bd2-a3aa-6ce380184b6c&level_two_taxon=272308f4-05c8-4d0d-abc7-b7c2e3ccd249&content_purpose_supergroup%5B%5D=news_and_communications&order=updated-newest"
   notifications:
     intro: "Stay up to date with GOV.UK"
     email_link: "Sign up to get emails when we add new coronavirus education and childcare information"

--- a/content/coronavirus_education_page.yml
+++ b/content/coronavirus_education_page.yml
@@ -11,13 +11,13 @@ content:
   guidance_section:
     header: What you can do now
     list:
-      - text: "Protective measures: keep children and staff safe when schools reopen" 
+      - text: "Protective measures: keep children and staff safe when schools reopen"
         url: /government/publications/coronavirus-covid-19-implementing-protective-measures-in-education-and-childcare-settings/coronavirus-covid-19-implementing-protective-measures-in-education-and-childcare-settings
       - text: "School reopenings: prepare to reopen your school"
         url: /government/publications/actions-for-educational-and-childcare-settings-to-prepare-for-wider-opening-from-1-june-2020/actions-for-education-and-childcare-settings-to-prepare-for-wider-opening-from-1-june-2020
   sections:
     - title: Support learning during coronavirus
-      sub_sections: 
+      sub_sections:
         - title: For parents
           list:
             - label: Guidance for parents and carers helping children learn from home
@@ -34,7 +34,7 @@ content:
       sub_sections:
         - title:
           list:
-            - label: "Protective measures: keep children and staff safe when schools reopen" 
+            - label: "Protective measures: keep children and staff safe when schools reopen"
               url: /government/publications/coronavirus-covid-19-implementing-protective-measures-in-education-and-childcare-settings/coronavirus-covid-19-implementing-protective-measures-in-education-and-childcare-settings
             - label: Free school meals
               url: /government/publications/covid-19-free-school-meals-guidance
@@ -46,7 +46,7 @@ content:
               url: /government/publications/coronavirus-covid-19-send-risk-assessment-guidance
             - label: Safeguarding and remote education
               url: /guidance/safeguarding-and-remote-education-during-coronavirus-covid-19
-            - label: Keep children safe online 
+            - label: Keep children safe online
               url: /government/publications/coronavirus-covid-19-keeping-children-safe-online/coronavirus-covid-19-support-for-parents-and-carers-to-keep-children-safe-online
     - title: School reopenings, exams and managing a school or early years setting
       sub_sections:
@@ -55,8 +55,8 @@ content:
             - label: Exam cancellations, results and appeals
               url: /government/publications/coronavirus-covid-19-cancellation-of-gcses-as-and-a-levels-in-2020
         - title: School closures, reopenings, and working safely
-          list:       
-            - label: Preparing for the wider opening of schools from 1 June 
+          list:
+            - label: Preparing for the wider opening of schools from 1 June
               url: /government/publications/preparing-for-the-wider-opening-of-schools-from-1-june
             - label: Schools opening for children of critical (key) workers and vulnerable children
               url: /government/publications/coronavirus-covid-19-maintaining-educational-provision
@@ -64,11 +64,11 @@ content:
               url: /government/publications/covid-19-school-closures
             - label: Closures guidance for early years and childcare
               url: /government/publications/coronavirus-covid-19-early-years-and-childcare-closures
-            - label: Closures guidance for colleges and further education providers 
+            - label: Closures guidance for colleges and further education providers
               url: /government/publications/coronavirus-covid-19-maintaining-further-education-provision
-            - label: Safe working in education, childcare and children’s social care 
+            - label: Safe working in education, childcare and children’s social care
               url: /government/publications/safe-working-in-education-childcare-and-childrens-social-care
-    - title: Funding and support for education and childcare 
+    - title: Funding and support for education and childcare
       sub_sections:
         - title:
           list:
@@ -78,8 +78,8 @@ content:
               url: /government/publications/coronavirus-covid-19-financial-support-for-education-early-years-and-childrens-social-care
             - label: Exceptional costs funding for schools
               url: /government/publications/coronavirus-covid-19-financial-support-for-schools
-            - label: Check if you can get Tax-Free Childcare and 30 hours free childcare during coronavirus (COVID-19) 
-              url: /guidance/check-if-you-can-get-tax-free-childcare-and-30-hours-free-childcare-during-coronavirus-covid-19  
+            - label: Check if you can get Tax-Free Childcare and 30 hours free childcare during coronavirus (COVID-19)
+              url: /guidance/check-if-you-can-get-tax-free-childcare-and-30-hours-free-childcare-during-coronavirus-covid-19
     - title: Student accommodation, travel and financial support
       sub_sections:
         - title:

--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -29,7 +29,7 @@ content:
       published_text: Published 11 May 2020
   see_all_announcements_link:
     text: See all announcements
-    href: "/search/news-and-communications?parent=/coronavirus-taxon&topic=5b7b9532-a775-4bd2-a3aa-6ce380184b6c&order=updated-newest"
+    href: "/search/all?level_one_taxon=5b7b9532-a775-4bd2-a3aa-6ce380184b6c&content_purpose_supergroup%5B%5D=news_and_communications&order=updated-newest"
   risk_level:
     #set show_risk_level_section to true to display the risk/alert level section on the landing page
     show_risk_level_section: false
@@ -262,9 +262,9 @@ content:
     header: "All coronavirus information on GOV.UK"
     links:
       - label: "Guidance"
-        url: "/search/all?level_one_taxon=5b7b9532-a775-4bd2-a3aa-6ce380184b6c"
+        url: "/search/all?level_one_taxon=5b7b9532-a775-4bd2-a3aa-6ce380184b6c&content_purpose_supergroup%5B%5D=guidance_and_regulation&order=most-viewed"
       - label: "News"
-        url: "/search/news-and-communications?parent=/coronavirus-taxon&topic=5b7b9532-a775-4bd2-a3aa-6ce380184b6c&order=updated-newest"
+        url: "/search/all?level_one_taxon=5b7b9532-a775-4bd2-a3aa-6ce380184b6c&content_purpose_supergroup%5B%5D=news_and_communications&order=updated-newest"
   notifications:
     intro: "Stay up to date with GOV.UK"
     email_link: "Sign up to get emails when we change any coronavirus information on the GOV.UK website"


### PR DESCRIPTION
We want to restrict guidance to _actual_ guidance at this point.

We also don't want to use the topic finder style search (which is what
the /search/news-and-communications page does for us), because it doesn't
give easy ways of navigating to more information right now.

So, we've moved to just using standard facets on site search.

Guidance is ordered by most-viewed, because this reassures people that they're
looking at the right place (they're likely to have heard of the popular items).

News is ordered by recency, because contemporaneous information is most important
here.

(Some trailing whitespace has also been tidied up)