### PR TITLE
landing_page: Update /apply-coronavirus-test link to avoid redirect

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -87,7 +87,7 @@ content:
             - label: Apply for a test if you have coronavirus symptoms
               url: https://www.nhs.uk/conditions/coronavirus-covid-19/testing-for-coronavirus/ask-for-a-test-to-check-if-you-have-coronavirus/
             - label: Apply for a test if you are an essential worker
-              url: /apply-coronavirus-test
+              url: /apply-coronavirus-test-essential-workers
             - label: Apply for tests for a care home
               url: /apply-coronavirus-test-care-home
             - label: Book a test if you have a verification code


### PR DESCRIPTION
:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

# What

`/apply-coronavirus-test` was redirecting to `/apply-coronavirus-test-essential-workers`. This updates it to link directly to that second page.
# Why

Users get what they need _a tiny bit faster_ than before.
