### PR TITLE
Add headings to hub pages accordions

### DIFF
--- a/content/coronavirus_business_page.yml
+++ b/content/coronavirus_business_page.yml
@@ -17,6 +17,7 @@ content:
         url: /guidance/claim-for-wages-through-the-coronavirus-job-retention-scheme
       - text: Find out how to apply for a grant if you’re self-employed
         url: /guidance/claim-a-grant-through-the-coronavirus-covid-19-self-employment-income-support-scheme
+  sections_heading: "Guidance and support"
   sections:
     - title: Funding and support
       sub_sections:

--- a/content/coronavirus_education_page.yml
+++ b/content/coronavirus_education_page.yml
@@ -15,6 +15,7 @@ content:
         url: /government/publications/coronavirus-covid-19-implementing-protective-measures-in-education-and-childcare-settings/coronavirus-covid-19-implementing-protective-measures-in-education-and-childcare-settings
       - text: "School reopenings: prepare to reopen your school"
         url: /government/publications/actions-for-educational-and-childcare-settings-to-prepare-for-wider-opening-from-1-june-2020/actions-for-education-and-childcare-settings-to-prepare-for-wider-opening-from-1-june-2020
+  sections_heading: "Guidance and support"
   sections:
     - title: Support learning during coronavirus
       sub_sections:


### PR DESCRIPTION
:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

# What
Add heading 'Guidance and support' heading above accordions on Education and Business hub pages.

# Why
To make the hub pages consistent with the landing page, which already has this heading above the accordion.

Trello card: https://trello.com/c/zmqJHAZg/298-add-guidance-and-support-heading-above-the-accordion-on-hub-pages
