### PR TITLE
Added new link to 'School closures' accordion

### DIFF
--- a/content/coronavirus_education_page.yml
+++ b/content/coronavirus_education_page.yml
@@ -69,6 +69,8 @@ content:
               url: /government/publications/coronavirus-covid-19-maintaining-further-education-provision
             - label: Safe working in education, childcare and children’s social care
               url: /government/publications/safe-working-in-education-childcare-and-childrens-social-care
+            - label: Supporting children and young people with SEND as schools and colleges prepare for wider opening
+              url: /government/publications/coronavirus-covid-19-send-risk-assessment-guidance
     - title: Funding and support for education and childcare
       sub_sections:
         - title:


### PR DESCRIPTION
What: New link added. 
Link text: Supporting children and young people with SEND as schools and colleges prepare for wider opening
URL: /government/publications/coronavirus-covid-19-send-risk-assessment-guidance
Where: 
Accordion: School reopenings, exams and managing a school or early years setting
Subsection: 'School closures, reopenings, and working safely' 

Why: Request came from DfE.

:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

# What
<!-- eg Changes to accordion links on the Coronavirus business page -->

# Why
<!-- eg Request from BEIS -->
