### PR TITLE
New link added

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -242,6 +242,8 @@ content:
               url: /bereavement-support-payment
             - label: Check if you can get help with funeral costs
               url: /funeral-payments
+            - label: Get support if you are dealing with a bereavement
+              url: /after-a-death/bereavement-help-and-support?step-by-step-nav=4f1fe77d-f43b-4581-baf9-e2600e2a2b7a
   additional_country_guidance:
     text: "Additional guidance for"
     links:


### PR DESCRIPTION
What:
New link added to 'support if someone dies'
Link text: Get support if you are dealing with a bereavement
Link: /after-a-death/bereavement-help-and-support?step-by-step-nav=4f1fe77d-f43b-4581-baf9-e2600e2a2b7a

Why:
Signpost support.

:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

# What
<!-- eg Changes to accordion links on the Coronavirus business page -->

# Why
<!-- eg Request from BEIS -->
