### PR TITLE
Deleted link 'get support to find work'

### DIFF
--- a/content/coronavirus_worker_page.yml
+++ b/content/coronavirus_worker_page.yml
@@ -54,8 +54,6 @@ content:
               url: /discrimination-your-rights/discrimination-at-work
         - title: Looking for work
           list:
-            - label: Get support to find work
-              url: /moving-from-benefits-to-work
             - label: Find a job
               url: /find-a-job
             - label: Improve your digital and numeracy skills with free online courses


### PR DESCRIPTION
What: Deleted link from 'Not working or working less'
            - label: Get support to find work
              url: /moving-from-benefits-to-work

Why: DWP says the information on this page is incorrect and they're getting lots of calls to the call centre.

:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

# What
<!-- eg Changes to accordion links on the Coronavirus business page -->

# Why
<!-- eg Request from BEIS -->
