### PR TITLE
Fix Coronavirus Risk Assessment Typo

### DIFF
--- a/content/coronavirus_business_page.yml
+++ b/content/coronavirus_business_page.yml
@@ -69,7 +69,7 @@ content:
           list:
             - label: Find out how to make your workplace COVID-secure
               url: /workingsafely
-            - label: How to carry out a COVID-19 risk asssessment
+            - label: How to carry out a COVID-19 risk assessment
               url: https://www.hse.gov.uk/risk/assessment.htm
             - label: Cleaning your workplace safely
               url: /government/publications/covid-19-decontamination-in-non-healthcare-settings


### PR DESCRIPTION
:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

# What
Just fixes a small typo which I noticed on the site: `asssessment` -> `assessment`. :)

<img width="771" alt="Screenshot 2020-06-13 at 08 50 13" src="https://user-images.githubusercontent.com/43215253/84563394-2d2c7300-ad53-11ea-96a7-c6eb38ca08b7.png">