### PR TITLE
Update to Testing for coronavirus section

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -99,7 +99,7 @@ content:
             - label: Apply for tests for a care home
               url: /apply-coronavirus-test-care-home
             - label: Book a test if you have a verification code
-              url: https://test-for-coronavirus.service.gov.uk/appointment
+              url: https://test-for-coronavirus.service.gov.uk/register/start
     - title: Health and wellbeing
       sub_sections:
         - title:


### PR DESCRIPTION
Changed the link in Book a test if you have a verification code 

From: https://test-for-coronavirus.service.gov.uk/appointment

To: https://test-for-coronavirus.service.gov.uk/register/start

:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

# What
Changed the link in Book a test if you have a verification code 

# Why
Request from NHS
