### PR TITLE
Add content for landing page links

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -16,6 +16,13 @@ content:
       href: /government/publications/coronavirus-outbreak-faqs-what-you-can-and-cant-do/coronavirus-outbreak-faqs-what-you-can-and-cant-do
       link_text: "Read more about what you can and"
       link_nowrap_text: "cannot do"
+    link2:
+      href: /government/publications/coronavirus-outbreak-faqs-what-you-can-and-cant-do/coronavirus-outbreak-faqs-what-you-can-and-cant-do
+      link_text: "What you can and cannot do now"
+    link3:
+      href: /government/publications/coronavirus-outbreak-faqs-what-you-can-and-cant-do/coronavirus-outbreak-faqs-what-you-can-and-cant-do-after-4-july
+      link_text: "What you can and cannot do"
+      link_nowrap_text: "from 4 July"
   announcements_label: Announcements
   announcements:
     - text: "Lockdown restrictions to be eased from 4 July"


### PR DESCRIPTION
# What

There are now 2 versions of 'What you can and cannot do' one for before 4 July one for after 4 July.

This adds content for the new links which will temporarily be replacing the big action link on coronavirus landing page.

Have kept the code and content for the current action link, as we will be reverting to the 1 link layout soon in the future (in which case we can remove link2/link3).

**Before**

<img width="818" alt="Screenshot 2020-06-25 at 16 28 39" src="https://user-images.githubusercontent.com/7116819/85749684-f8300100-b700-11ea-8c5e-499b2aadd8d2.png">

**After**
![image](https://user-images.githubusercontent.com/7116819/85749726-0120d280-b701-11ea-8c91-1d4bedbf725d.png)


# Why
<!-- eg Request from BEIS -->
For users planning to do things in July we need to let them know what will be possible before and after the rules change.

https://trello.com/c/oB87oGqD