### PR TITLE
New link added to 'local lockdowns' accordion

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -114,7 +114,9 @@ content:
             - label: "Leicester coronavirus lockdown: areas and changes"
               url: /government/news/leicestershire-coronavirus-lockdown-areas-and-changes
             - label: Guidance from Leicester City Council
-              url: https://www.leicester.gov.uk/your-council/coronavirus/coronavirus-in-leicester/             
+              url: https://www.leicester.gov.uk/your-council/coronavirus/coronavirus-in-leicester/   
+            - label: "Local lockdowns: guidance for education and childcare settings" 
+              url: /government/publications/local-lockdowns-guidance-for-education-and-childcare-settings          
     - title: Work and financial support
       sub_sections:
         - title:


### PR DESCRIPTION
What: new link
Where: Local lockdown accordion
TEXT: "Local lockdowns: guidance for education and childcare settings" 
URL: /government/publications/local-lockdowns-guidance-for-education-and-childcare-settings   

Why: we urgently need guidance for people in Leicester - DfE is the first gov dept to get this ready (info for schools).

:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

# What
<!-- eg Changes to accordion links on the Coronavirus business page -->

# Why
<!-- eg Request from BEIS -->
