### PR TITLE
Changed accordion: Driving and transport in the UK

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -177,15 +177,15 @@ content:
               url: /guidance/coronavirus-covid-19-safer-travel-guidance-for-passengers
             - label: Safer transport guidance for operators
               url: /government/publications/coronavirus-covid-19-safer-transport-guidance-for-operators
-            - label: Car, motorcycle and van MOTs extended by 6 months
+            - label: Car, motorcycle and van MOTs extended by 6 months (until 1 August 2020) 
               url: /guidance/coronavirus-covid-19-mots-for-cars-vans-and-motorcycles-due-from-30-march-2020
-            - label: Driving tests and MOTs for heavy vehicles suspended
-              url: /government/news/driving-tests-and-mots-for-heavy-vehicles-suspended-for-up-to-3-months-to-help-tackle-spread-of-coronavirus
+            - label: Driving lessons, theory tests and driving tests suspended in England (until 4 July 2020)  
+              url: /government/news/driving-lessons-theory-tests-and-driving-tests-to-restart-in-england
+            - label: MOTs for HGVs, buses and trailers suspended (until 4 July 2020)  
+              url: /guidance/coronavirus-covid-19-mots-for-lorries-buses-and-trailers        
             - label: Renewals of lorry and bus driving licences for over 45s
-              url: /government/publications/applications-for-renewing-lorry-and-bus-driving-licences-at-age-45-and-over-during-the-coronavirus-covid-19-pandemic  
-            - label: Relaxation of drivers’ hours rules
-              url: /government/publications/covid-19-guidance-on-drivers-hours-relaxations/coronavirus-covid-19-guidance-on-drivers-hours-relaxations
-            - label: Vehicle approval tests suspended
+              url: /government/publications/applications-for-renewing-lorry-and-bus-driving-licences-at-age-45-and-over-during-the-coronavirus-covid-19-pandemic 
+            - label: Vehicle approval tests suspended (until 4 July 2020) 
               url: /guidance/coronavirus-covid-19-vehicle-approval-tests 
     - title: Healthcare workers, carers and care settings
       sub_sections:


### PR DESCRIPTION
What: 

1. 2 new links added:

A.
Driving lessons, theory tests and driving tests suspended in England (until 4 July 2020)  
/government/news/driving-lessons-theory-tests-and-driving-tests-to-restart-in-england

B.
MOTs for HGVs, buses and trailers suspended (until 4 July 2020)  
/guidance/coronavirus-covid-19-mots-for-lorries-buses-and-trailers

2. 2 links deleted
Driving tests and MOTs for heavy vehicles suspended
Relaxation of drivers’ hours rules 

3. Link text changed
Car, motorcycle and van MOTs extended by 6 months (until 1 August 2020)

:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

# What
<!-- eg Changes to accordion links on the Coronavirus business page -->

# Why
<!-- eg Request from BEIS -->
