### PR TITLE
Changed 'early years' to 'early-years'

### DIFF
--- a/content/coronavirus_education_page.yml
+++ b/content/coronavirus_education_page.yml
@@ -68,7 +68,7 @@ content:
           list:
             - label: Exam cancellations, results and appeals
               url: /government/publications/coronavirus-covid-19-cancellation-of-gcses-as-and-a-levels-in-2020
-        - title: Managing a school or early years setting
+        - title: Managing a school or early-years setting
           list:
             - label: Schools opening for children of critical (key) workers and vulnerable children 
               url: /government/publications/coronavirus-covid-19-maintaining-educational-provision

--- a/content/coronavirus_education_page.yml
+++ b/content/coronavirus_education_page.yml
@@ -68,7 +68,7 @@ content:
           list:
             - label: Exam cancellations, results and appeals
               url: /government/publications/coronavirus-covid-19-cancellation-of-gcses-as-and-a-levels-in-2020
-        - title: Managing a school or early-years setting
+        - title: Managing a school or early years setting
           list:
             - label: Schools opening for children of critical (key) workers and vulnerable children 
               url: /government/publications/coronavirus-covid-19-maintaining-educational-provision

--- a/content/coronavirus_education_page.yml
+++ b/content/coronavirus_education_page.yml
@@ -72,7 +72,7 @@ content:
           list:
             - label: Schools opening for children of critical (key) workers and vulnerable children 
               url: /government/publications/coronavirus-covid-19-maintaining-educational-provision
-            - label: Running an early-years setting during coronavirus 
+            - label: Running an early years setting during coronavirus 
               url: /government/publications/coronavirus-covid-19-early-years-and-childcare-closures
             - label: Running a school during coronavirus 
               url: /government/publications/actions-for-schools-during-the-coronavirus-outbreak


### PR DESCRIPTION
What: Changed 'early years' to 'early-years' across page
Why: I think it's wrong

:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

# What
<!-- eg Changes to accordion links on the Coronavirus business page -->

# Why
<!-- eg Request from BEIS -->
