### PR TITLE
Changed 1 link

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -224,7 +224,7 @@ content:
             - label: How to get food and other essential items
               url: /guidance/coronavirus-covid-19-accessing-food-and-essential-supplies
             - label: Support for victims of domestic violence
-              url: https://www.gov.uk/guidance/domestic-abuse-how-to-get-help
+              url: /guidance/domestic-abuse-how-to-get-help
     - title: Housing and accommodation
       sub_sections:
         - title:

--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -224,7 +224,7 @@ content:
             - label: How to get food and other essential items
               url: /guidance/coronavirus-covid-19-accessing-food-and-essential-supplies
             - label: Support for victims of domestic violence
-              url: /government/publications/coronavirus-covid-19-and-domestic-abuse/coronavirus-covid-19-support-for-victims-of-domestic-abuse
+              url: https://www.gov.uk/guidance/domestic-abuse-how-to-get-help
     - title: Housing and accommodation
       sub_sections:
         - title:


### PR DESCRIPTION
WHAT: Changed URL for domestic abuse

>>Accordion: Health and wellbeing
>>Link text: Support for victims of domestic violence

NEW URL:https://www.gov.uk/guidance/domestic-abuse-how-to-get-help

WHY: Old guidance withdrawn and redirect put in place. This is just housekeeping even though the old link was redirecting.

:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

# What
<!-- eg Changes to accordion links on the Coronavirus business page -->

# Why
<!-- eg Request from BEIS -->
