### PR TITLE
Added link to Eat Out to Help Out Scheme guide

### DIFF
--- a/content/coronavirus_business_page.yml
+++ b/content/coronavirus_business_page.yml
@@ -37,6 +37,8 @@ content:
               url: https://www.gov.uk/government/publications/coronavirus-covid-19-guidance-for-uk-businesses/coronavirus-covid-19-guidance-for-uk-businesses-trading-internationally
             - label: Rules that have been relaxed to help businesses during the coronavirus pandemic
               url: /guidance/rules-that-have-been-relaxed-to-help-businesses-during-the-coronavirus-pandemic
+            - label: Register your establishment for the Eat Out to Help Out Scheme
+              url: /guidance/register-your-establishment-for-the-eat-out-to-help-out-scheme 
     - title: Self-employed people and sole traders
       sub_sections:
         - title:


### PR DESCRIPTION
:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

**This change needs to go live at 9am on Thursday 9 July.**

# What
Added link to new HMRC guidance on the Eat Out to Help Out scheme to the 'Funding and support' section of the business support hub. 

# Why
Requested by HMRC and approved by Cabinet Office in the following Zendesk thread: https://govuk.zendesk.com/agent/tickets/4146242
