### PR TITLE
Changed accordion name

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -60,7 +60,7 @@ content:
   explainer_text:
   sections_heading: "Guidance and support"
   sections:
-    - title: Protect yourself and others from coronavirus
+    - title: Self-isolating, social distancing and shielding
       sub_sections:
         - title:
           list:


### PR DESCRIPTION
WHAT:
Changed accordion name 

FROM: 'Protect yourself and others'
to: 'Self-isolating, social distancing and shielding'

WHY:
Users are searching for 'shielding' and 'sheilding' but not clicking through to this accordion. We think the accordion name needs to name-checking 'shielding'.

:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

# What
<!-- eg Changes to accordion links on the Coronavirus business page -->

# Why
<!-- eg Request from BEIS -->
