### PR TITLE
Updated 2 links

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -178,12 +178,12 @@ content:
               url: /government/publications/coronavirus-covid-19-safer-transport-guidance-for-operators
             - label: Renewals of lorry and bus driving licences for people over 45
               url: /government/publications/applications-for-renewing-lorry-and-bus-driving-licences-at-age-45-and-over-during-the-coronavirus-covid-19-pandemic 
-        - title: In Scotland and Wales
+        - title: Driving and theory tests
           list:            
-            - label: Theory tests suspended 
-              url: /guidance/coronavirus-theory-tests-scotland-and-wales 
-            - label: Driving tests suspended
-              url: /guidance/coronavirus-driving-tests-scotland-and-wales
+            - label: Find out when theory tests are restarting 
+              url: /guidance/coronavirus-theory-tests 
+            - label: Find out when driving tests are restarting 
+              url: /guidance/coronavirus-covid-19-driving-tests-and-theory-tests
         - title: Until 1 August 2020  
           list:  
             - label: Car, motorcycle and van MOTs extended by 6 months  


### PR DESCRIPTION
WHAT:

CHANGED FROM: 
SUBSECTION: In Scotland and Wales
TEXT: Theory tests suspended
URL: /guidance/coronavirus-theory-tests
TEXT: Driving tests suspended
URL: https://www.gov.uk/guidance/coronavirus-covid-19-driving-tests-and-theory-tests

CHANGED TO:
SUBSECTION: Driving and theory tests
TEXT: Find out when theory tests are restarting 
URL: /guidance/coronavirus-theory-tests
TEXT: Find out when driving tests are restarting 
URL: https://www.gov.uk/guidance/coronavirus-covid-19-driving-tests-and-theory-tests

WHY: Driving and theory tests aren't suspended any more. DfT has changed the guidance (pages are redirecting atm).

:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

# What
<!-- eg Changes to accordion links on the Coronavirus business page -->

# Why
<!-- eg Request from BEIS -->
