### PR TITLE
Changed link text

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -262,7 +262,7 @@ content:
           list:
             - label: How to volunteer
               url: /volunteering/coronavirus-volunteering
-            - label: Volunteer for vaccine research
+            - label: Join a vaccine research study
               url: https://www.nhs.uk/conditions/coronavirus-covid-19/research/coronavirus-vaccine-research/
             - label: Join a genetic study if you tested positive for coronavirus
               url: https://www.genomicsengland.co.uk/covid-19/


### PR DESCRIPTION
WHAT: 

Text:  Join a vaccine research study

WHERE:

Volunteering and offering help

WHY:

We now have 2 links that recruit volunteers for research study. The link text was not consistent, so I've changed the text to make them consistent.

:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

# What
<!-- eg Changes to accordion links on the Coronavirus business page -->

# Why
<!-- eg Request from BEIS -->
