### PR TITLE
Replaced NW restrictions content with self-employed

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -19,9 +19,9 @@ content:
       link_nowrap_text: "cannot do"
   announcements_label: Announcements
   announcements:
-    - text: "North West of England: local restrictions – what you can and cannot do"
-      href: /guidance/north-west-of-england-local-restrictions-what-you-can-and-cannot-do
-      published_text: Published 31 July 2020
+    - text: "Millions of self employed to benefit from second stage of support scheme"
+      href: /government/news/million-of-self-employed-to-benefit-from-second-stage-of-support-scheme
+      published_text: Published 17 August 2020
     - text: "Self-isolating period changes from 7 to 10 days"
       href: /government/news/statement-from-the-uk-chief-medical-officers-on-extension-of-self-isolation-period-30-july-2020
       published_text: Published 30 July 2020


### PR DESCRIPTION
High number of on-page searches for self-employment. Local restrictions has highest levels of accordion opens.

:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

# What
<!-- eg Changes to accordion links on the Coronavirus business page -->

# Why
<!-- eg Request from BEIS -->
