### PR TITLE
Update coronavirus_landing_page.yml

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -49,8 +49,9 @@ content:
       - a new, continuous cough
       - a loss of, or change to, your sense of smell or taste
     call_to_action:
-      title: Get a test now. Do not leave home for at least 10 days
-      href: https://www.nhs.uk/conditions/coronavirus-covid-19/check-if-you-have-coronavirus-symptoms/
+      title: Get a test now
+      href: https://www.gov.uk/get-coronavirus-test
+    paragraph: Do not leave home for at least 10 days after your test  
   find_help:
     heading: "Find out what support you can get"
     paragraph: "For example, if you’re out of work, need to get food, or want to take care of your mental health."


### PR DESCRIPTION
Zendesk: https://govuk.zendesk.com/agent/tickets/4186914

In line 53 (part of the NHS box), I've:

1. Changed the call-to-action link from https://www.nhs.uk/conditions/coronavirus-covid-19/check-if-you-have-coronavirus-symptoms , to https://www.gov.uk/get-coronavirus-test . Because: CTA text and link need to match.

2. Deleted '. Do not leave home for at least 10 days' from the link text. Because: it works better as its own line, and full stops in link text break our style rules.

3. Added new line (54): 'Do not leave home for at least 10 days after your test'. Because: see point 2. Have included 'after your test' to make clear when the 10 days starts from.

NOTE: I'm not sure if 'paragraph:' is actually the right styling for point 3.... am taking a bit of a chance!

:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

# What
<!-- eg Changes to accordion links on the Coronavirus business page -->

# Why
<!-- eg Request from BEIS -->
