### PR TITLE
Update coronavirus_landing_page.yml

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -49,9 +49,8 @@ content:
       - a new, continuous cough
       - a loss of, or change to, your sense of smell or taste
     call_to_action:
-      title: Get a test now
-      href: https://www.gov.uk/get-coronavirus-test
-    paragraph: Do not leave home for at least 10 days after your test  
+      title: Get a test now - do not leave home for at least 10 days after your test
+      href: https://www.gov.uk/get-coronavirus-test  
   find_help:
     heading: "Find out what support you can get"
     paragraph: "For example, if you’re out of work, need to get food, or want to take care of your mental health."


### PR DESCRIPTION
1. Deleted line 54 ('Do not leave home for 10 days after your test').
Because: It wasn't displaying. Think this is down to wrong code being used - a dev will take a look tomorrow, but in the meantime I need to do a workaround...
2. Added '- do not leave home for at least 10 days after your test' to the link test (line 53).
Because: It's the best place to put it until we can find a way to display it on its own line.

:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

# What
<!-- eg Changes to accordion links on the Coronavirus business page -->

# Why
<!-- eg Request from BEIS -->
