### PR TITLE
Update coronavirus_education_page.yml

### DIFF
--- a/content/coronavirus_education_page.yml
+++ b/content/coronavirus_education_page.yml
@@ -15,7 +15,7 @@ content:
           url: https://www.nidirect.gov.uk/articles/coronavirus-covid-19-advice-schools-colleges-and-universities
     list_heading: "In England:"
     list:
-      - childminders can return to work
+      - there's new guidance on face coverings in schools
       - schools will reopen to all age groups from September
   guidance_section:
     header: What you can do now


### PR DESCRIPTION
line 18:
- replaced the bullet point 'childminders can return to work'
- with 'there’s new guidance on face coverings in schools'
- because the former was old news

:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

# What
<!-- eg Changes to accordion links on the Coronavirus business page -->

# Why
<!-- eg Request from BEIS -->
