### PR TITLE
Update coronavirus_education_page.yml

### DIFF
--- a/content/coronavirus_education_page.yml
+++ b/content/coronavirus_education_page.yml
@@ -4,27 +4,18 @@ content:
   page_title: "Education and childcare"
   header_section:
     pretext: Guidance for teachers, school leaders, carers, parents and students
-    education-pretext:
-      text: Find out when schools are expected to reopen in
-      countries:
-        - label: Scotland
-          url: https://www.gov.scot/news/schools-to-re-open-in-august/
-        - label: Wales
-          url: https://gov.wales/how-schools-will-work-during-coronavirus-pandemic#section-38402
-        - label: Northern Ireland
-          url: https://www.nidirect.gov.uk/articles/coronavirus-covid-19-advice-schools-colleges-and-universities
-    list_heading: "In England:"
     list:
-      - there's new guidance on face coverings in schools
-      - schools will reopen to all age groups from September
+      - Schools have reopened to all age groups in England, Scotland and Northern Ireland
+      - Schools in Wales have begun reopening and will all reopen by 14 September
+      - There's new guidance on [face coverings in England](/face-coverings-in-education)
   guidance_section:
     header: What you can do now
     list:
-      - text: Safe working in education, childcare and children’s social care
+      - text: Check how to work safely in education and childcare
         url: /government/publications/safe-working-in-education-childcare-and-childrens-social-care
-      - text: Guidance for parents and carers on how schools, early years providers and colleges will open in September 
+      - text: Find out how your child's start or return to education should be managed
         url: /government/publications/what-parents-and-carers-need-to-know-about-early-years-providers-schools-and-colleges-during-the-coronavirus-covid-19-outbreak/what-parents-and-carers-need-to-know-about-early-years-providers-schools-and-colleges-in-the-autumn-term
-      - text: Check how childminders, holiday clubs and after school clubs can operate
+      - text: Check how childminders, after school clubs and holiday clubs can operate
         url: /government/publications/guidance-for-parents-and-carers-of-children-attending-out-of-school-settings-during-the-coronavirus-covid-19-outbreak/guidance-for-parents-and-carers-of-children-attending-out-of-school-settings-during-the-coronavirus-covid-19-outbreak
   sections_heading: "Guidance and support"
   # sections are edited in https://collections-publisher.publishing.service.gov.uk/coronavirus/education


### PR DESCRIPTION
Changes detailed in https://docs.google.com/document/d/12XTvcSBpi5Hc6EC4jSb3uvXKE4-k854yQumg3qC2YJQ/edit# . 
Summary:
- updated the banner bullets to make them more current 
- removing 'Find out when schools are expected to reopen in Scotland, Wales and Northern Ireland' (no longer needed, because of the above)
- changing the 'What you can do now' link text for each bullet, so that each one is more active and addresses the intended audience

:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

# What
<!-- eg Changes to accordion links on the Coronavirus business page -->

# Why
<!-- eg Request from BEIS -->
