### PR TITLE
Remove content in NHS box

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -49,7 +49,6 @@ content:
     call_to_action:
       title: Get a test now
       href: https://www.gov.uk/get-coronavirus-test
-      description: Do not leave home for at least 10 days after your test
   find_help:
     heading: "Find out what support you can get"
     paragraph: "For example, if you’re out of work, need to get food, or want to take care of your mental health."


### PR DESCRIPTION
Removed content in NHS box, telling users to self-isolate for 10 days after taking the test. This is only the case if you test positive. T

:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

# What
<!-- eg Changes to accordion links on the Coronavirus business page -->

# Why
<!-- eg Request from BEIS -->
