### PR TITLE
Update coronavirus_education_page.yml

### DIFF
--- a/content/coronavirus_education_page.yml
+++ b/content/coronavirus_education_page.yml
@@ -5,9 +5,7 @@ content:
   header_section:
     pretext: Guidance for teachers, school leaders, carers, parents and students
     list:
-      - Schools have reopened to all age groups in England, Scotland and Northern Ireland
-      - Schools in Wales have begun reopening and will all reopen by 14 September
-      - There's new guidance on face coverings in England
+      - Schools have reopened to all age groups in England, Scotland, Wales and Northern Ireland
   guidance_section:
     header: What you can do now
     list:


### PR DESCRIPTION
1. line 8 - CHANGED
'Schools have reopened to all age groups in England, Scotland and Northern Ireland'
TO
'Schools have reopened to all age groups in England, Scotland, Wales and Northern Ireland'
BECAUSE
Schools in Wales are now open too.

2. REMOVED the lines directly below, i.e.
'Schools in Wales have begun reopening and will all reopen by 14 September
There's new guidance on face coverings in England'
BECAUSE
We don't need the line about Wales any more, and the face coverings guidance is no longer new.

:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

# What
<!-- eg Changes to accordion links on the Coronavirus business page -->

# Why
<!-- eg Request from BEIS -->
