### PR TITLE
Updated Scotland link

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -82,7 +82,7 @@ content:
     text: "See specific guidance for"
     links:
       - label: "Scotland"
-        url: /guidance/coronavirus-covid-19-information-for-individuals-and-businesses-in-scotland
+        url: https://www.gov.scot/coronavirus-covid-19/
       - label: "Wales"
         url: https://gov.wales/coronavirus
       - label: "Northern Ireland"


### PR DESCRIPTION
Changed link to: https://www.gov.scot/coronavirus-covid-19/

WHY:

It's the only one that doesn't link to a devolved nation's website.

:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

# What
<!-- eg Changes to accordion links on the Coronavirus business page -->

# Why
<!-- eg Request from BEIS -->
