### PR TITLE
Deleted rule of 6 from header

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -15,7 +15,6 @@ content:
       href: /government/publications/coronavirus-outbreak-faqs-what-you-can-and-cant-do/coronavirus-outbreak-faqs-what-you-can-and-cant-do
       link_text: "Find out what you need to do"
       link_nowrap_text: ""
-      subtext: "You must not meet in groups larger than 6 (with some limited exceptions)"
   announcements_label: Announcements
   announcements:
     - text: "Chancellor announces Job Support Scheme as part of Winter Economy Plan"


### PR DESCRIPTION
The rule of 6 is now represented in the timeline.

:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

# What
<!-- eg Changes to accordion links on the Coronavirus business page -->

# Why
<!-- eg Request from BEIS -->
