### PR TITLE
Update coronavirus_education_page.yml

### DIFF
--- a/content/coronavirus_education_page.yml
+++ b/content/coronavirus_education_page.yml
@@ -9,8 +9,8 @@ content:
   guidance_section:
     header: What you can do now
     list:
-      - text: Read guidance on face coverings in England
-        url: /government/publications/face-coverings-in-education
+      - text: Check how local coronavirus restrictions affect you
+        url: /find-coronavirus-local-restrictions
       - text: Check how to work safely in education and childcare
         url: /government/publications/safe-working-in-education-childcare-and-childrens-social-care
       - text: Find out how your child's start or return to education should be managed


### PR DESCRIPTION
In 'What you can do now' 

In rows 12 and 13, REPLACED the 'Face coverings' link with the following, SO THAT users know how the new local covid alert levels affect them:

text: Check how local coronavirus restrictions affect you
url: /find-coronavirus-local-restrictions

:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

# What
<!-- eg Changes to accordion links on the Coronavirus business page -->

# Why
<!-- eg Request from BEIS -->
