### PR TITLE
Update coronavirus_worker_page.yml

### DIFF
--- a/content/coronavirus_worker_page.yml
+++ b/content/coronavirus_worker_page.yml
@@ -19,8 +19,6 @@ content:
         url: /guidance/coronavirus-covid-19-what-to-do-if-you-were-employed-and-have-lost-your-job
       - text: Financial support if you’re self employed and getting less work or no work 
         url: /guidance/coronavirus-covid-19-what-to-do-if-youre-self-employed-and-getting-less-work-or-no-work
-      - text: How to return to work safely if you cannot work from home
-        url: /check-how-to-return-to-work-safely
   sections_heading: "Guidance and support"
   # sections are edited in https://collections-publisher.publishing.service.gov.uk/coronavirus/workers
   sections:


### PR DESCRIPTION
Rows 22 and 23

DELETED the 'How to return to work safely if you cannot work from home' link

BECAUSE forgot to do it earlier (it was supposed to go to make way for the new postcode lookup link)

:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

# What
<!-- eg Changes to accordion links on the Coronavirus business page -->

# Why
<!-- eg Request from BEIS -->
