### PR TITLE
Update coronavirus_landing_page.yml

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -17,9 +17,9 @@ content:
       link_nowrap_text: ""
   announcements_label: Announcements
   announcements:
-    - text: "Liverpool City Region to move into 'very high' Local COVID Alert Level following infection rise"
-      href: /government/news/liverpool-city-region-to-move-into-very-high-local-covid-alert-level-following-rise-in-coronavirus-infections
-      published_text: Published 12 October 2020
+    - text: "Barrow-in-Furness, Chesterfield, Elmbridge, Erewash, Essex, London boroughs, North East Derbyshire and York to move into 'High' Local COVID Alert Level"
+      href: /government/speeches/coronavirus-update-on-areas-in-local-covid-alert-levels
+      published_text: Published 15 October 2020
     - text: "Prime Minister announces new Local COVID Alert Levels"
       href: /government/news/prime-minister-announces-new-local-covid-alert-levels
       published_text: Published 12 October 2020
@@ -62,12 +62,16 @@ content:
   timeline:
     heading: Recent and upcoming changes
     list:
-      - heading: 14 October
+     - heading: 17 October
+        paragraph: |
+          ‘High’ Local COVID Alert Level to apply to Barrow-in-Furness, Chesterfield, Elmbridge, Erewash, Essex, London boroughs, North East Derbyshire and York
+     - heading: 15 October
         paragraph: |
           [Local COVID Alert Levels](/guidance/local-covid-alert-levels-what-you-need-to-know) apply in your area
       - heading: 14 October
-        paragraph: | 
-          [Liverpool City Region placed on ‘Very High’ Local Covid Alert Level](/government/news/liverpool-city-region-to-move-into-very-high-local-covid-alert-level-following-rise-in-coronavirus-infections)  
+        paragraph: |
+          [Liverpool City Region placed on ‘Very High’ Local Covid Alert Level](/government/news/liverpool-city-region-to-move-into-very-high-local-covid-alert-level-following-rise-in-coronavirus-infections) 
+          17 October
       - heading: 24 September
         paragraph: |
           Get the [NHS COVID-19 app](https://covid19.nhs.uk/) to help protect yourself and others 


### PR DESCRIPTION
1. Rows 65-67: ADDED new timeline item following today's announcement on areas moving into 'High' alert. No link for now.

2. Rows 20-22: ADDED new announcement on areas moving into 'High' alert, with link to press release.

3. (Formerly rows 23-25) DELETED announcement on Liverpool facing new restrictions, because we need to take one thing out (and it's currently in the timeline anyway).

:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

# What
<!-- eg Changes to accordion links on the Coronavirus business page -->

# Why
<!-- eg Request from BEIS -->
