### PR TITLE
New timeline item added

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -65,6 +65,9 @@ content:
       - heading: 17 October
         paragraph: | 
           [‘High’ Local COVID Alert Level](/guidance/full-list-of-local-covid-alert-levels-by-area) applies to Barrow-in-Furness, Chesterfield, Elmbridge, Erewash, Essex, London boroughs, North East Derbyshire and York
+      - heading: 17 October
+        paragraph: | 
+          ['Very High’ Local COVID Alert Level](/guidance/local-covid-alert-level-very-high?priority-taxon=774cee22-d896-44c1-a611-e3109cce8eae) applies to Lancashire
       - heading: 14 October
         paragraph: |
           [Local COVID Alert Levels](/guidance/local-covid-alert-levels-what-you-need-to-know) apply in your area


### PR DESCRIPTION
Date: 17 October
Link text: 'Very High’ Local COVID Alert Level applies to Lancashire
URL: /guidance/local-covid-alert-level-very-high?priority-taxon=774cee22-d896-44c1-a611-e3109cce8eae

:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

# What
<!-- eg Changes to accordion links on the Coronavirus business page -->

# Why
<!-- eg Request from BEIS -->
