### PR TITLE
changed link in timeline

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -67,7 +67,7 @@ content:
           [People arriving in England from Italy after 4am will need to self-isolate](/government/news/italy-removed-from-travel-corridor-list-and-crete-added-to-list-for-england)
       - heading: 17 October
         paragraph: | 
-          [Local COVID Alert Level: High](/guidance/full-list-of-local-covid-alert-levels-by-area) applies to Barrow-in-Furness, Chesterfield, Elmbridge, Erewash, Essex, London boroughs, North East Derbyshire and York
+          [Local COVID Alert Level: High](/guidance/local-covid-alert-level-high) applies to Barrow-in-Furness, Chesterfield, Elmbridge, Erewash, Essex, London boroughs, North East Derbyshire and York
       - heading: 17 October
         paragraph: | 
           [Local COVID Alert Level: Very High](/guidance/local-covid-alert-level-very-high?priority-taxon=774cee22-d896-44c1-a611-e3109cce8eae) applies to Lancashire


### PR DESCRIPTION
WHAT:

URL change to: /guidance/local-covid-alert-level-high

IN: 
-17 October
- [Local COVID Alert Level: High](/guidance/local-covid-alert-level-high) applies to Barrow-in-Furness, Chesterfield, Elmbridge, Erewash, Essex, London boroughs, North East Derbyshire and York

REASON:

Links weren't consistent.

:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

# What
<!-- eg Changes to accordion links on the Coronavirus business page -->

# Why
<!-- eg Request from BEIS -->
