### PR TITLE
Timeline (URL updated)

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -67,7 +67,7 @@ content:
           [People arriving in England from Italy after 4am will need to self-isolate](/government/news/italy-removed-from-travel-corridor-list-and-crete-added-to-list-for-england)
       - heading: 17 October
         paragraph: | 
-          [Local COVID Alert Level: High](/guidance/full-list-of-local-covid-alert-levels-by-area) applies to Barrow-in-Furness, Chesterfield, Elmbridge, Erewash, Essex, London boroughs, North East Derbyshire and York
+          [Local COVID Alert Level: High](/guidance/local-covid-alert-level-high) applies to Barrow-in-Furness, Chesterfield, Elmbridge, Erewash, Essex, London boroughs, North East Derbyshire and York
       - heading: 17 October
         paragraph: | 
           [Local COVID Alert Level: Very High](/guidance/local-covid-alert-level-very-high?priority-taxon=774cee22-d896-44c1-a611-e3109cce8eae) applies to Lancashire


### PR DESCRIPTION
WHAT:

Added new URL to the timeline (17 Oct).

New URL: /guidance/local-covid-alert-level-high

Why:
Links weren't consistent. The 'very high' one went to a dedicated page. The 'high' one went to a page about all alert levels (now changed to the dedicated page).

:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

# What
<!-- eg Changes to accordion links on the Coronavirus business page -->

# Why
<!-- eg Request from BEIS -->
