### PR TITLE
Update coronavirus_landing_page.yml

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -18,7 +18,7 @@ content:
   announcements_label: Announcements
   announcements:
     - text: "Greater Manchester moves to Local COVID Alert Level: Very High on 23 October"
-      href: /government/speeches/prime-ministers-statement-on-coronavirus-covid-19-20-october-2020
+      href: /government/news/local-covid-alert-level-update-for-greater-manchester
       published_text: Published 20 October 2020
     - text: "Lancashire moves to Local COVID Alert Level: Very High on 17 October"
       href: /government/news/local-covid-alert-level-update-for-lancashire


### PR DESCRIPTION
Link under 'Announcements' Greater Manchester:
- changed to /government/news/local-covid-alert-level-update-for-greater-manchester 
- from /government/speeches/prime-ministers-statement-on-coronavirus-covid-19-20-october-2020

:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

# What
<!-- eg Changes to accordion links on the Coronavirus business page -->

# Why
<!-- eg Request from BEIS -->
