### PR TITLE
Update coronavirus_landing_page.yml

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -19,7 +19,7 @@ content:
   announcements:
     - text: "South Yorkshire moves to Local COVID Alert Level: Very High on 24 October"
       href: /government/news/local-covid-alert-level-update-for-south-yorkshire
-      published_text: Published 20 October 2020
+      published_text: Published 21 October 2020
     - text: "Greater Manchester moves to Local COVID Alert Level: Very High on 23 October"
       href: /government/news/local-covid-alert-level-update-for-greater-manchester
       published_text: Published 20 October 2020

--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -17,15 +17,15 @@ content:
       link_nowrap_text: ""
   announcements_label: Announcements
   announcements:
+    - text: "South Yorkshire moves to Local COVID Alert Level: Very High on 24 October"
+      href: /government/news/local-covid-alert-level-update-for-south-yorkshire
+      published_text: Published 20 October 2020
     - text: "Greater Manchester moves to Local COVID Alert Level: Very High on 23 October"
       href: /government/news/local-covid-alert-level-update-for-greater-manchester
       published_text: Published 20 October 2020
     - text: "Lancashire moves to Local COVID Alert Level: Very High on 17 October"
       href: /government/news/local-covid-alert-level-update-for-lancashire
       published_text: Published 16 October 2020
-    - text: "Barrow-in-Furness, Chesterfield, Elmbridge, Erewash, Essex, London boroughs, North East Derbyshire and York to move into 'High' Local COVID Alert Level"
-      href: /government/speeches/coronavirus-update-on-areas-in-local-covid-alert-levels
-      published_text: Published 15 October 2020
   see_all_announcements_link:
     text: See all announcements
     href: "/search/all?level_one_taxon=5b7b9532-a775-4bd2-a3aa-6ce380184b6c&content_purpose_supergroup%5B%5D=news_and_communications&order=updated-newest"
@@ -62,6 +62,9 @@ content:
   timeline:
     heading: Recent and upcoming changes
     list:
+      - heading: 24 October
+        paragraph: | 
+          [Local COVID Alert Level: Very High](/guidance/local-covid-alert-level-very-high?priority-taxon=774cee22-d896-44c1-a611-e3109cce8eae) applies to Barnsley, Doncaster, Rotherham and Sheffield
       - heading: 23 October
         paragraph: | 
           [Local COVID Alert Level: Very High](/guidance/local-covid-alert-level-very-high?priority-taxon=774cee22-d896-44c1-a611-e3109cce8eae) applies to Greater Manchester
@@ -71,9 +74,6 @@ content:
       - heading: 17 October
         paragraph: | 
           [Local COVID Alert Level: Very High](/guidance/local-covid-alert-level-very-high?priority-taxon=774cee22-d896-44c1-a611-e3109cce8eae) applies to Lancashire
-      - heading: 14 October
-        paragraph: |
-          [Local COVID Alert Levels](/guidance/local-covid-alert-levels-what-you-need-to-know) apply in your area
   sections_heading: "Guidance and support"
   # sections are edited in https://collections-publisher.publishing.service.gov.uk/coronavirus/landing
   sections:


### PR DESCRIPTION
Updating timeline and annoucements for South Yorkshire going into Very high. Namely:

- Deleting from timeline: 14 October, Local COVID Alert Levels apply in your area 
- Adding to timeline: 24 October, Local COVID Alert Level: Very High applies to Barnsley, Doncaster, Rotherham and Sheffield

- Deleting from announcements: Barrow-in-Furness, Chesterfield, Elmbridge, Erewash, Essex, London boroughs, North East Derbyshire and York to move into 'High' Local COVID Alert Level, Published 15 October 2020
- Adding to announcements: South Yorkshire moves to Local COVID Alert Level: Very High on 24 October, Published 21 October 2020

:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

# What
<!-- eg Changes to accordion links on the Coronavirus business page -->

# Why
<!-- eg Request from BEIS -->
