### PR TITLE
Update coronavirus_landing_page.yml

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -62,6 +62,9 @@ content:
   timeline:
     heading: Recent and upcoming changes
     list:
+      - heading: 29 October
+        paragraph: | 
+          [Local COVID Alert Level: Very High](/guidance/local-covid-alert-level-very-high?priority-taxon=774cee22-d896-44c1-a611-e3109cce8eae) applies to Warrington
       - heading: 25 October
         paragraph: | 
           [People arriving from the Canary Islands, Denmark, Maldives and Mykonos do not need to self-isolate](/government/news/canary-islands-denmark-maldives-and-mykonos-added-to-travel-corridor-exempt-list) 
@@ -71,9 +74,6 @@ content:
       - heading: 24 October
         paragraph: | 
           [Local COVID Alert Level: Very High](/guidance/local-covid-alert-level-very-high?priority-taxon=774cee22-d896-44c1-a611-e3109cce8eae) applies to Barnsley, Doncaster, Rotherham and Sheffield
-      - heading: 23 October
-        paragraph: | 
-          [Local COVID Alert Level: Very High](/guidance/local-covid-alert-level-very-high?priority-taxon=774cee22-d896-44c1-a611-e3109cce8eae) applies to Greater Manchester
       
   sections_heading: "Guidance and support"
   # sections are edited in https://collections-publisher.publishing.service.gov.uk/coronavirus/landing


### PR DESCRIPTION
Added Warrington to timeline - moving to Very High on 29 October.
The date may change, awaiting confirmation.

:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

# What
Added Warrington to timeline on /coronavirus.
Date must be confirmed and updated before publishing this change.

# Why
Preparing for No10 request
