### PR TITLE
Update coronavirus_business_page.yml

### DIFF
--- a/content/coronavirus_business_page.yml
+++ b/content/coronavirus_business_page.yml
@@ -6,8 +6,7 @@ content:
     pretext: Coronavirus (COVID-19) support is available to businesses
     list:
       - Loans, tax relief and cash grants are available
-      - Employers can apply for staff to get up to 80% pay if they can’t work
-      - Self-employed people can receive up to £2,500 per month in grants for at least 3 months
+      - Employers may be eligible for financial support to pay wages
   guidance_section:
     header: What you can do now
     list:


### PR DESCRIPTION
1. CHANGED line 9 FROM 
Employers can apply for staff to get up to 80% pay if they can’t work
 TO
 Employers may be eligible for financial support to pay wages 
BECAUSE  
New scheme is coming in from 1 Nov with different percentages. The old scheme will sort of be running alongside it for a bit. (Hence this line is intentionally generic for now.) 
2. DELETED line 10 (about the self employed)
BECAUSE
The old scheme is coming to an end tomorrow (Saturday - we have no weekend cover). We're awaiting fresh information on the new scheme, but can't publish anything yet. We can add something in later today, if we hear, or else Monday morning.

:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

# What
<!-- eg Changes to accordion links on the Coronavirus business page -->

# Why
<!-- eg Request from BEIS -->
