### PR TITLE
Update coronavirus_business_page.yml

### DIFF
--- a/content/coronavirus_business_page.yml
+++ b/content/coronavirus_business_page.yml
@@ -15,7 +15,7 @@ content:
       - text: "Make your workplace COVID-secure"
         url: /guidance/working-safely-during-coronavirus-covid-19
       - text: "Find out how to apply for a grant if you’re self-employed"
-        url: /guidance/claim-a-grant-through-the-coronavirus-covid-19-self-employment-income-support-scheme
+        url: /government/publications/self-employment-income-support-scheme-grant-extension
       - text: "Check how local coronavirus restrictions affect your business"
         url: /find-coronavirus-local-restrictions     
   sections_heading: "Guidance and support"


### PR DESCRIPTION
line 18

CHANGED URL FROM
https://www.gov.uk/guidance/claim-a-grant-through-the-coronavirus-covid-19-self-employment-income-support-scheme
TO
https://www.gov.uk/government/publications/self-employment-income-support-scheme-grant-extension 
BECAUSE 
Former guidance has been withdrawn.

:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

# What
<!-- eg Changes to accordion links on the Coronavirus business page -->

# Why
<!-- eg Request from BEIS -->
