### PR TITLE
Update coronavirus_landing_page.yml

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -17,7 +17,7 @@ content:
       link_nowrap_text: ""
   announcements_label: Announcements
   announcements:
-    - text: "Liverpool to be regularly tested for coronavirus in first whole city testing pilot"
+    - text: "First city testing pilot will begin in Liverpool from 6 November"
       href: /government/news/liverpool-to-be-regularly-tested-for-coronavirus-in-first-whole-city-testing-pilot
       published_text: Published 3 November 2020
     - text: "Prime Minister's statement on national restrictions in England from 5 November"

--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -17,15 +17,15 @@ content:
       link_nowrap_text: ""
   announcements_label: Announcements
   announcements:
+    - text: "Liverpool to be regularly tested for coronavirus in first whole city testing pilot"
+      href: /government/news/liverpool-to-be-regularly-tested-for-coronavirus-in-first-whole-city-testing-pilot
+      published_text: Published 3 November 2020
     - text: "Prime Minister's statement on national restrictions in England from 5 November"
       href: /government/speeches/prime-ministers-statement-on-coronavirus-covid-19-31-october-2020
       published_text: Published 31 October 2020
     - text: "Furlough extended and further support for businesses announced"
       href: /government/news/furlough-scheme-extended-and-further-economic-support-announced
       published_text: Published 31 October 2020   
-    - text: "Sewage signals early warning of coronavirus outbreaks"
-      href: /government/news/sewage-signals-early-warning-of-coronavirus-outbreaks
-      published_text: Published 23 October 2020
   see_all_announcements_link:
     text: See all announcements
     href: "/search/all?level_one_taxon=5b7b9532-a775-4bd2-a3aa-6ce380184b6c&content_purpose_supergroup%5B%5D=news_and_communications&order=updated-newest"


### PR DESCRIPTION
Update to the Announcements section of the landing page as follows.

Replacing:
Sewage signals early warning of coronavirus outbreaks
Published 23 October 2020

With: 
Liverpool to be regularly tested for coronavirus in first whole city testing pilot
Published 3 November 2020

:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

# What
<!-- eg Changes to accordion links on the Coronavirus business page -->

# Why
<!-- eg Request from BEIS -->
