### PR TITLE
Announcements update

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -17,12 +17,12 @@ content:
       link_nowrap_text: ""
   announcements_label: Announcements
   announcements:
+    - text: "Clinically extremely vulnerable people - new guidance"
+      href: /government/news/clinically-extremely-vulnerable-receive-updated-guidance-in-line-with-new-national-restrictions
+      published_text: Published 4 November 2020
     - text: "First city testing pilot will begin in Liverpool from 6 November"
       href: /government/news/liverpool-to-be-regularly-tested-for-coronavirus-in-first-whole-city-testing-pilot
       published_text: Published 3 November 2020
-    - text: "Prime Minister's statement on national restrictions in England from 5 November"
-      href: /government/speeches/prime-ministers-statement-on-coronavirus-covid-19-31-october-2020
-      published_text: Published 31 October 2020
     - text: "Furlough extended and further support for businesses announced"
       href: /government/news/furlough-scheme-extended-and-further-economic-support-announced
       published_text: Published 31 October 2020   


### PR DESCRIPTION
Update to Announcements section:
- Added clinically extremely vulnerable people announcement, published 4 November
- Removed Prime Minister national measure announcement, published 31 October

:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

# What
<!-- eg Changes to accordion links on the Coronavirus business page -->

# Why
<!-- eg Request from BEIS -->
