### PR TITLE
Timeline update

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -62,9 +62,18 @@ content:
   timeline:
     heading: Recent and upcoming changes
     list:
+      - heading: 6 November
+        paragraph: | 
+            "Everyone who lives or works in Liverpool will be offered coronavirus tests, whether or not they have symptoms."
       - heading: 5 November
         paragraph: | 
             [National restrictions now apply to England](/guidance/new-national-restrictions-from-5-november)
+     list:
+      - you cannot meet socially with anyone indoors unless they’re in your support bubble
+      - there are changes to how many people you can meet outside
+      - you must not travel in the UK or overseas, unless for a specific reason, like education, work or a caring responsibility     
+       paragraph: | 
+            [Clinically extremely vulnerable people are advised to stay at home, except for exercise or essential health appointments](/government/publications/guidance-on-shielding-and-protecting-extremely-vulnerable-persons-from-covid-19/guidance-on-shielding-and-protecting-extremely-vulnerable-persons-from-covid-19)
   sections_heading: "Guidance and support"
   # sections are edited in https://collections-publisher.publishing.service.gov.uk/coronavirus/landing
   sections:

--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -68,7 +68,7 @@ content:
       - heading: 5 November
         paragraph: | 
             [National restrictions now apply to England](/guidance/new-national-restrictions-from-5-november)
-     list:
+      - list:
       - you cannot meet socially with anyone indoors unless they’re in your support bubble
       - there are changes to how many people you can meet outside
       - you must not travel in the UK or overseas, unless for a specific reason, like education, work or a caring responsibility     


### PR DESCRIPTION
Changes to the timeline as follows:

6 November
Everyone who lives or works in Liverpool will be offered coronavirus tests, whether or not they have symptoms.

5 November
National restrictions now apply to England:
- you cannot meet socially with anyone indoors unless they’re in your support bubble
- there are changes to how many people you can meet outside
- you must not travel in the UK or overseas, unless for a specific reason, like education, work or a caring responsibility
Clinically extremely vulnerable people are advised to stay at home, except for exercise or essential health appointments.

:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

# What
<!-- eg Changes to accordion links on the Coronavirus business page -->

# Why
<!-- eg Request from BEIS -->
