### PR TITLE
Adds changes to travel advice for Denmark, Sweden and Germany

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -62,9 +62,16 @@ content:
   timeline:
     heading: Recent and upcoming changes
     list:
+      - heading: 7 November
+        paragraph: |
+            [People returning from Sweden and Germany must self-isolate](/government/news/germany-and-sweden-removed-from-travel-corridor-list-of-exempt-countries).
+            
+            [Visitors from Denmark arriving in the UK will be denied entry](/government/news/travel-ban-implemented-to-protect-public-health-following-denmark-covid-19-mink-outbreak).
       - heading: 6 November
         paragraph: |
             [Everyone who lives or works in Liverpool will be offered coronavirus tests, whether or not they have symptoms](/guidance/getting-tested-for-coronavirus-if-you-live-or-work-in-liverpool).
+            
+            [UK residents returning from Denmark must self-isolate](/government/news/transport-secretary-statement-on-denmark).
       - heading: 5 November
         paragraph: |
             [National restrictions now apply to England](/guidance/new-national-restrictions-from-5-november):


### PR DESCRIPTION
# What
Includes new advice for passengers from Denmark, Germany and Sweden
# Why
So people know they what they must do - approved by Cabinet Office.
