### PR TITLE
Tweak to the NHS symptoms box

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -41,7 +41,7 @@ content:
       href: /risk-level
       text: Read more about COVID-19 alert levels
   nhs_banner:
-    heading: "If you have coronavirus symptoms:"
+    heading: "If you have any coronavirus symptoms:"
     list:
       - a high temperature
       - a new, continuous cough


### PR DESCRIPTION
FROM: If you have coronavirus symptoms

TO: If you have any coronavirus symptoms

REASON: Zendesk ticket: https://govuk.zendesk.com/agent/tickets/4338144 - user pointed out that it looks like you need all symptoms before you can get a test, when you only need 1 symptom.

:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

# What
<!-- eg Changes to accordion links on the Coronavirus business page -->

# Why
<!-- eg Request from BEIS -->
