### PR TITLE
Adding Winter Plan to timeline

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -62,6 +62,9 @@ content:
   timeline:
     heading: Recent and upcoming changes
     list:
+      - heading: 23 November
+        paragraph: |
+            Government releases [Winter Plan](/government/publications/covid-19-winter-plan) for managing coronavirus
       - heading: 5 November
         paragraph: |
             [National restrictions apply to England](/guidance/new-national-restrictions-from-5-november):


### PR DESCRIPTION
Adding, 23 November -  Government releases Winter Plan for managing coronavirus

:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

# What
<!-- eg Changes to accordion links on the Coronavirus business page -->

# Why
<!-- eg Request from BEIS -->
