### PR TITLE
Added 1 new statistic

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -97,6 +97,8 @@ content:
         url: https://coronavirus.data.gov.uk/
       - label: UK data and analysis on coronavirus
         url: /guidance/coronavirus-covid-19-statistics-and-analysis
+      - label: Coronavirus cases by local authority
+        url: /government/collections/coronavirus-cases-by-local-authority-epidemiological-data
       - label: Weekly data on testing in the UK
         url: /government/collections/nhs-test-and-trace-statistics-england-weekly-reports
       - label: Statistics on coronavirus funding for business


### PR DESCRIPTION
WHAT:
      - label: Coronavirus cases by local authority
        url: /government/collections/coronavirus-cases-by-local-authority-epidemiological-data

WHY:
Request from DHSC. Apparently users are struggling to find it.

:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

# What
<!-- eg Changes to accordion links on the Coronavirus business page -->

# Why
<!-- eg Request from BEIS -->
