### PR TITLE
Added 1 link to 'Statistics' section

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -91,7 +91,7 @@ content:
         url: https://coronavirus.data.gov.uk/
       - label: UK data and analysis on coronavirus
         url: /guidance/coronavirus-covid-19-statistics-and-analysis
-      - label: Latest data and trends about the coronavirus (Office for National Statistics)
+      - label: Latest data and trends about coronavirus (Office for National Statistics)
         url: https://www.ons.gov.uk/peoplepopulationandcommunity/healthandsocialcare/conditionsanddiseases/articles/coronaviruscovid19/latestinsights
       - label: Coronavirus cases by local authority
         url: /government/collections/coronavirus-cases-by-local-authority-epidemiological-data

--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -91,7 +91,7 @@ content:
         url: https://coronavirus.data.gov.uk/
       - label: UK data and analysis on coronavirus
         url: /guidance/coronavirus-covid-19-statistics-and-analysis
-      - label: Latest data and trends about coronavirus (COVID-19) (Office for National Statistics)
+      - label: Latest data and trends about coronavirus (COVID-19) from the Office for National Statistics
         url: https://www.ons.gov.uk/peoplepopulationandcommunity/healthandsocialcare/conditionsanddiseases/articles/coronaviruscovid19/latestinsights
       - label: Coronavirus cases by local authority
         url: /government/collections/coronavirus-cases-by-local-authority-epidemiological-data

--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -91,7 +91,7 @@ content:
         url: https://coronavirus.data.gov.uk/
       - label: UK data and analysis on coronavirus
         url: /guidance/coronavirus-covid-19-statistics-and-analysis
-      - label: Latest data and trends about coronavirus (Office for National Statistics)
+      - label: Latest data and trends about coronavirus (COVID-19) (Office for National Statistics)
         url: https://www.ons.gov.uk/peoplepopulationandcommunity/healthandsocialcare/conditionsanddiseases/articles/coronaviruscovid19/latestinsights
       - label: Coronavirus cases by local authority
         url: /government/collections/coronavirus-cases-by-local-authority-epidemiological-data

--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -91,6 +91,8 @@ content:
         url: https://coronavirus.data.gov.uk/
       - label: UK data and analysis on coronavirus
         url: /guidance/coronavirus-covid-19-statistics-and-analysis
+      - label: Latest data and trends about the coronavirus (Office for National Statistics)
+        url: https://www.ons.gov.uk/peoplepopulationandcommunity/healthandsocialcare/conditionsanddiseases/articles/coronaviruscovid19/latestinsights
       - label: Coronavirus cases by local authority
         url: /government/collections/coronavirus-cases-by-local-authority-epidemiological-data
       - label: Weekly data on testing in the UK


### PR DESCRIPTION
TEXT: Latest data and trends about coronavirus (COVID-19) (Office for National Statistics)
URL: https://www.ons.gov.uk/peoplepopulationandcommunity/healthandsocialcare/conditionsanddiseases/articles/coronaviruscovid19/latestinsights

:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

# What
<!-- eg Changes to accordion links on the Coronavirus business page -->

# Why
<!-- eg Request from BEIS -->
