### PR TITLE
Update coronavirus_landing_page.yml

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -54,11 +54,6 @@ content:
   timeline:
     heading: Recent and upcoming changes
     list:
-      - heading: 23 to 27 December
-        paragraph: |
-            [You can make a Christmas bubble with friends and family](/government/publications/making-a-christmas-bubble-with-friends-and-family/making-a-christmas-bubble-with-friends-and-family)
-
-            Follow guidance on [Christmas activities](/guidance/guidance-for-the-christmas-period)
       - heading: 19 December
         paragraph: |
             Parts of England will move tiers - follow the rules in your local area


### PR DESCRIPTION
:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

# What
Removing reference to Christmas bubbles from timeline

# Why
Request from Rory O'Donoghue
Will reinstate once updated Christmas guidance is live
