### PR TITLE
Update coronavirus_education_page.yml

### DIFF
--- a/content/coronavirus_education_page.yml
+++ b/content/coronavirus_education_page.yml
@@ -13,7 +13,7 @@ content:
       - text: Find out about the return to school and childcare in January 2021
         url: /government/publications/schools-and-childcare-settings-return-in-january-2021/schools-and-childcare-settings-return-in-january-2021
       - text: Find out which areas are required to implement the contingency framework from January 2021
-        url: /government/publications/coronavirus-covid-19-contingency-framework-for-education-and-childcare-settings/contingency-framework-education-and-childcare-settings-excluding-universities
+        url: /government/publications/coronavirus-covid-19-contingency-framework-for-education-and-childcare-settings
       - text: Find out about mass asymptomatic testing in schools and colleges from January 2021
         url: /government/publications/coronavirus-covid-19-asymptomatic-testing-in-schools-and-colleges/coronavirus-covid-19-asymptomatic-testing-in-schools-and-colleges
   sections_heading: "Guidance and support"


### PR DESCRIPTION
changed URL to point to splash page because info users need isn't in the HTML publication we were pointing to

:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

# What
<!-- eg Changes to accordion links on the Coronavirus business page -->

# Why
<!-- eg Request from BEIS -->
