### PR TITLE
Remove prefix for the action link label

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -12,7 +12,7 @@ content:
       Stay 2 metres apart from anyone not in your household or bubble.
     link:
       href: /guidance/national-lockdown-stay-at-home
-      link_text: Find out what you can and cannot do
+      text: Find out what you can and cannot do
       link_nowrap_text: ""
   announcements_label: Announcements
   # Announcements are edited in https://collections-publisher.publishing.service.gov.uk/coronavirus/landing


### PR DESCRIPTION
:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

# What
Remove prefix for the action link label

# Why
To match the expected name in `collections` frontend
