### PR TITLE
Change link href to url

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -11,7 +11,7 @@ content:
 
       Stay 2 metres apart from anyone not in your household or bubble.
     link:
-      href: /guidance/national-lockdown-stay-at-home
+      url: /guidance/national-lockdown-stay-at-home
       text: Find out what you can and cannot do
       link_nowrap_text: ""
   announcements_label: Announcements


### PR DESCRIPTION
In
https://github.com/alphagov/collections/commit/203b18ef191acc5bd306721df76e721c32df3168
the variable for this got changed from a href attribute to a url
attribute.

The simplest, fastest way to fix this rapidly seems to be changing this
variable name.

:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

# What
<!-- eg Changes to accordion links on the Coronavirus business page -->

# Why
<!-- eg Request from BEIS -->
