### PR TITLE
Duplicate header link variables to transition variable names

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -11,8 +11,12 @@ content:
 
       Stay 2 metres apart from anyone not in your household or bubble.
     link:
+      # Temporarily setting both url and href to support a transition from url to href, if you need to change one change both
       url: /guidance/national-lockdown-stay-at-home
+      href: /guidance/national-lockdown-stay-at-home
+      # Temporarily setting both text and link_text to support a transition from text to link_text, if you need to change one change both
       text: Find out what you can and cannot do
+      link_text: Find out what you can and cannot do
       link_nowrap_text: ""
   announcements_label: Announcements
   # Announcements are edited in https://collections-publisher.publishing.service.gov.uk/coronavirus/landing


### PR DESCRIPTION
In https://github.com/alphagov/collections/pull/2206/files#diff-ce8ea314cd8b38b89a839207c9df92eeb91d154ac8fe60ea6436f9d0bc935287L88-L97
we replaced variables with hardcoded text. When we then re-introduced
the variables they were given different names: https://github.com/alphagov/collections/pull/2210/files#diff-ce8ea314cd8b38b89a839207c9df92eeb91d154ac8fe60ea6436f9d0bc935287L70-L79

This PR aims to temporarily using both names so that we can transition
back to the old names. It seems that we currently have code set-up for
link2 and link3 that'll use the previous naming convention so this will
make them consistent.

Unfortunately this approach doesn't seem to make link and link copy
handling consistent across this file there seems to be lots of places
using `url` for links and lots using `href` this place also seems to be
the only place which prefixes text with `link_`. So I'm not sure this is
the most valuable clean-up to make.

:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

# What
<!-- eg Changes to accordion links on the Coronavirus business page -->

# Why
<!-- eg Request from BEIS -->
