### PR TITLE
Fix Coronavirus Vaccinations Typo

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -70,7 +70,7 @@ content:
   statistics_section:
     header: UK statistics
     links:
-      - label: Daily summary of coronavirus testing, cases and vaccinatons
+      - label: Daily summary of coronavirus testing, cases and vaccinations
         url: https://coronavirus.data.gov.uk/
       - label: All data and analysis on coronavirus
         url: /guidance/coronavirus-covid-19-statistics-and-analysis


### PR DESCRIPTION
:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

# What
<!-- eg Changes to accordion links on the Coronavirus business page -->

Just fixes a typo which I noticed on the Coronavirus landing page. :) 

<img width="714" alt="Screenshot 2021-02-04 at 10 38 22" src="https://user-images.githubusercontent.com/43215253/106881300-3e0c6900-66d5-11eb-9b1a-00fa371ff4f0.png">

