### PR TITLE
Add a summary section to timeline

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -53,6 +53,8 @@ content:
   # Timeline entries are edited in https://collections-publisher.publishing.service.gov.uk/coronavirus/landing
   timeline:
     heading: Roadmap out of lockdown
+    summary: |
+      A [4-step plan to ease lockdown in England](/government/publications/covid-19-response-spring-2021) has been announced.
   sections_heading: "Guidance and support"
   # sections are edited in https://collections-publisher.publishing.service.gov.uk/coronavirus/landing
   sections:


### PR DESCRIPTION
This is to meet an immediate need of some additional context between
the timeline header and the timeline entries.

:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

# What
<!-- eg Changes to accordion links on the Coronavirus business page -->

# Why
<!-- eg Request from BEIS -->
