### PR TITLE
Create coronavirus_education_page.yml

### DIFF
--- a/content/coronavirus_education_page.yml
+++ b/content/coronavirus_education_page.yml
@@ -15,8 +15,9 @@ content:
           url: https://www.nidirect.gov.uk/articles/coronavirus-covid-19-advice-schools-colleges-and-universities
     list_heading: "In England:"
     list:
-      - secondary school pupils, college students and staff are tested twice a week at school or college
-      - households and bubbles of pupils and staff can get twice-weekly home test kits
+      - secondary school pupils and college students are tested twice a week at school or college
+      - nursery, school and college staff are tested twice a week at work
+      - if you’re in a household, childcare or support bubble with nursery, school or college staff or pupils you can get twice-weekly rapid lateral flow tests
   guidance_section:
     header: Popular content
     list:

--- a/content/coronavirus_education_page.yml
+++ b/content/coronavirus_education_page.yml
@@ -17,7 +17,7 @@ content:
     list:
       - secondary school pupils and college students are tested twice a week at school or college
       - nursery, school and college staff are tested twice a week at work
-      - if you’re in a household, childcare or support bubble with nursery, school or college staff or pupils you can get twice-weekly rapid lateral flow tests
+      - you can get twice-weekly rapid lateral flow tests if you’re in a household, childcare or support bubble with nursery, school or college staff or pupils
   guidance_section:
     header: Popular content
     list:


### PR DESCRIPTION
Nursery staff and parents can get tests
This is not clear from the bullets at the top of the education hub
Nursery children are probably not called ‘students’

https://docs.google.com/document/d/1JzEoxnlsQlu0rwxug8JBnF3ql3NghC-ZlybvUjoM7B8/edit#

Trello - https://trello.com/c/qw5i0VtS/1132-add-nurseries-to-top-of-education-hub

:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

# What
<!-- eg Changes to accordion links on the Coronavirus business page -->

# Why
<!-- eg Request from BEIS -->
