### PR TITLE
Replace nhs_banner copy

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -31,16 +31,14 @@ content:
       href: /risk-level
       text: Read more about COVID-19 alert levels
   nhs_banner:
-    heading: "If you have any coronavirus symptoms:"
-    list:
-      - a high temperature
-      - a new, continuous cough
-      - a loss of, or change to, your sense of smell or taste
-    call_to_action:
-      title: Get a test
-      subtext: and stay at home
-      href: https://www.gov.uk/get-coronavirus-test
-      description:
+    sections:
+      - heading: "If you have no symptoms:"
+        markdown: |
+          Check if you should get [regular rapid lateral flow tests](/getting-tested-for-coronavirus).
+      - heading: "If you have coronavirus symptoms:"
+        markdown: |
+          - [get a PCR test](/get-coronavirus-test)
+          - stay at home
   find_help:
     heading: "Find out what support you can get"
     paragraph: "For example, if you’re out of work, need to get food, or want to take care of your mental health."


### PR DESCRIPTION
Trello: https://trello.com/c/NSprpQLr/295-update-nhs-box

On March 29th the NHS notice on /coronavirus changed format
substantially [1] and thus required the content to all be replaced and a
new structure formed.

This ports this new structure to this file.

[1]: https://github.com/alphagov/collections/pull/2342
