### PR TITLE
Add phrases for statistical data

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -67,6 +67,24 @@ content:
         url: https://www.nidirect.gov.uk/campaigns/coronavirus-covid-19
   statistics_section:
     header: UK statistics
+    cumulative_vaccinations:
+      title: Total vaccinations
+      statistic_meaning: people have received their first dose
+      guidance_link:
+        label: Vaccination data from the coronavirus data dashboard
+        url: https://coronavirus.data.gov.uk/details/vaccinations
+    hospital_admissions:
+      title: Daily hospital admissions
+      statistic_meaning: new patients have been admitted to hospital
+      guidance_link:
+        label: Healthcare data from the coronavirus data dashboard
+        url: https://coronavirus.data.gov.uk/details/healthcare
+    new_positive_tests:
+      title: Daily new cases
+      statistic_meaning: people tested positive with COVID-19
+      guidance_link:
+        label: Cases data from the coronavirus data dashboard
+        url: https://coronavirus.data.gov.uk/details/cases
     links:
       - label: Daily summary of coronavirus testing, cases and vaccinations
         url: https://coronavirus.data.gov.uk/

--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -71,7 +71,7 @@ content:
       - label: Daily summary of coronavirus testing, cases and vaccinations
         url: https://coronavirus.data.gov.uk/
       - label: Data and trends from the Office for National Statistics (ONS)
-        url: https://www.ons.gov.uk/peoplepopulationandcommunity/healthandsocialcare/conditionsanddiseases      
+        url: https://www.ons.gov.uk/peoplepopulationandcommunity/healthandsocialcare/conditionsanddiseases
       - label: All data and analysis on coronavirus
         url: /guidance/coronavirus-covid-19-statistics-and-analysis
       - label: Coronavirus cases by local authority


### PR DESCRIPTION
Trello: https://trello.com/c/WVZPCn3t/203-embed-covid-statistics-into-coronavirus-page

This adds the phrasing around the data that will be shown on
/coronavirus for UK statistics. It's rather coupled to the
implementation so will probably be a little delicate to edit, but
convention does seem to be that nearly all copy is in this file.