### PR TITLE
Add related links section to Coronavirus hub pages

### DIFF
--- a/content/coronavirus_business_page.yml
+++ b/content/coronavirus_business_page.yml
@@ -18,6 +18,13 @@ content:
   sections_heading: "Guidance and support"
   # sections are edited in https://collections-publisher.publishing.service.gov.uk/coronavirus/business
   sections:
+  related_topic_section:
+    header: "Related coronavirus topics"
+    links:
+      - label: "Education, universities and childcare"
+        url: "/coronavirus/education-and-childcare"
+      - label: "Work and financial support"
+        url: "/coronavirus/worker-support"
   topic_section:
     header: "All coronavirus business support information on GOV.UK"
     links:

--- a/content/coronavirus_education_page.yml
+++ b/content/coronavirus_education_page.yml
@@ -22,13 +22,20 @@ content:
   guidance_section:
     header: Popular content
     list:
-      - text: Order rapid lateral flow tests to do twice a week, for example if you’re a parent or carer 
-        url: /order-coronavirus-rapid-lateral-flow-tests  
+      - text: Order rapid lateral flow tests to do twice a week, for example if you’re a parent or carer
+        url: /order-coronavirus-rapid-lateral-flow-tests
       - text: Parents and carers - what you need to know
         url: /government/publications/what-parents-and-carers-need-to-know-about-early-years-providers-schools-and-colleges-during-the-coronavirus-covid-19-outbreak
   sections_heading: "Guidance and support"
   # sections are edited in https://collections-publisher.publishing.service.gov.uk/coronavirus/education
   sections:
+  related_topic_section:
+    header: "Related coronavirus topics"
+    links:
+      - label: "Business support"
+        url: "/coronavirus/business-support"
+      - label: "Work and financial support"
+        url: "/coronavirus/worker-support"
   topic_section:
     header: "All coronavirus education, university and childcare information on GOV.UK"
     links:

--- a/content/coronavirus_worker_page.yml
+++ b/content/coronavirus_worker_page.yml
@@ -13,7 +13,7 @@ content:
     header: What you can do now
     list:
       - text: Furlough - find information on the Job Retention Scheme
-        url: /guidance/check-if-you-could-be-covered-by-the-coronavirus-job-retention-scheme 
+        url: /guidance/check-if-you-could-be-covered-by-the-coronavirus-job-retention-scheme
       - text: Self-employed - what to do if you’re getting less or no work
         url: /guidance/coronavirus-covid-19-what-to-do-if-youre-self-employed-and-getting-less-work-or-no-work
       - text: Not working - what to do if you’re employed but cannot work
@@ -23,6 +23,13 @@ content:
   sections_heading: "Guidance and support"
   # sections are edited in https://collections-publisher.publishing.service.gov.uk/coronavirus/workers
   sections:
+  related_topic_section:
+    header: "Related coronavirus topics"
+    links:
+      - label: "Business support"
+        url: "/coronavirus/business-support"
+      - label: "Education, universities and childcare"
+        url: "/coronavirus/education-and-childcare"
   topic_section:
     header: All coronavirus work and financial support information on GOV.UK
     links:


### PR DESCRIPTION
In order to help users navigate between Coronavirus hub pages, we want to add links to all other Coronavirus hub pages on each Coronavirus hub page within a new UI component.

For example: on the `business` hub page we'd add links to the `education` and `worker` hub pages, and on the `education` hub page we'd add links to the `business` and `worker` hub pages.

This change adds content for the link labels, the URLs and a header for each hub page with will be used to render these links.

[Trello](https://trello.com/c/m5y819Z0/337-build-the-related-links-element-for-hub-pages)

:warning: Only merge this pull request if you are happy for the changes to be made live :warning:
