### PR TITLE
Remove live stream section

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -111,34 +111,6 @@ content:
     intro: "Stay up to date with GOV.UK"
     email_link: "Sign up to get emails when we change any coronavirus information on the GOV.UK website"
     email_url: "/email-signup?topic=/coronavirus-taxon"
-  live_stream:
-    show_live_stream: false
-    title: Press conferences and speeches
-    date_text: Broadcast
-    no_cookies:
-      change_settings: "Change your cookie settings"
-      change_settings_link: "/help/cookies"
-      to_watch: "to watch the video"
-      or: "or"
-      watch_link_text: "Watch on YouTube"
-      icon_text: "Video"
-    previous_videos:
-      url: https://www.youtube.com/user/Number10gov/videos
-      previous_videos_text: Watch all press conferences on YouTube
-      next_conference_text: The next live press conference will be shown here
-    # set spaced_links to true to insert breaks in the list of links, for increased legibility
-    spaced_links: true
-    ask_a_question_visible: false
-    ask_a_question_text: Ask a question at a press conference
-    ask_a_question_link: /ask
-    popular_questions_link_visible: false
-    see_popular_questions_text: See answers to the most common topics asked about by the public
-    see_popular_questions_link: /guidance/answers-to-the-most-common-topics-asked-about-by-the-public-for-the-coronavirus-press-conference
-    transcript_text: Read all press conference statements
-    transcript_link: /government/collections/slides-and-datasets-to-accompany-coronavirus-press-conferences#transcripts
-    # video_url and date are set by https://collections-publisher.publishing.service.gov.uk/coronavirus/live_stream
-    video_url:
-    date:
   # https://schema.org/SpecialAnnouncement fields
   special_announcement_schema:
     category: https://www.wikidata.org/wiki/Q81068910


### PR DESCRIPTION
Trello: https://trello.com/c/qIMREu2x
Depends on: https://github.com/alphagov/collections-publisher/pull/1355

# What's changed?

Remove the content for the live stream section.

# Why?

The current live stream of press conferences used to be streamed on the
coronavirus landing page. However this stopped in summer 2020 and hasn't
been used since). Removing the section removes a lot of clutter from this file.

:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

# What
<!-- eg Changes to accordion links on the Coronavirus business page -->

# Why
<!-- eg Request from BEIS -->
