### PR TITLE
Remove find support box content

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -39,12 +39,6 @@ content:
         markdown: |
           - [get a PCR test](/get-coronavirus-test)
           - stay at home
-  find_help:
-    heading: "Find out what support you can get"
-    paragraph: "For example, if you’re out of work, need to get food, or want to take care of your mental health."
-    link:
-      href: "/find-coronavirus-support"
-      text: "Find support"
   explainer_title:
   explainer_text:
   # Timeline entries are edited in https://collections-publisher.publishing.service.gov.uk/coronavirus/landing


### PR DESCRIPTION
:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

Trello: https://trello.com/c/A2td7o1B

# What
Remove the Find Support box content for the Landing Page.

# Why
We believe that removing the box will improve the performance of the page by making it easier to find more popular and useful content and services. The link to the find support tool will instead be added to an accordion using the publishing tool.
