### PR TITLE
Update coronavirus_landing_page.yml

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -45,7 +45,6 @@ content:
   # Timeline entries are edited in https://collections-publisher.publishing.service.gov.uk/coronavirus/landing
   timeline:
     heading: Recent and upcoming changes
-    summary: Restrictions are easing across the UK.
   sections_heading: "Guidance and support"
   # sections are edited in https://collections-publisher.publishing.service.gov.uk/coronavirus/landing
   sections:


### PR DESCRIPTION
Remove the line 'restrictions are easing across the UK'.

:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

# What
Remove the line 'restrictions are easing across the UK' from the timeline on the coronavirus landing page. 

# Why
It no longer fits with the content that follows on the page since we are between steps. It's also not featured on the new design including the DA picker. The change has been OKed by C19.
