### PR TITLE
Link update to 'cases by local authority'

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -86,8 +86,8 @@ content:
         url: https://www.ons.gov.uk/peoplepopulationandcommunity/healthandsocialcare/conditionsanddiseases
       - label: All data and analysis on coronavirus
         url: /guidance/coronavirus-covid-19-statistics-and-analysis
-      - label: Coronavirus cases by local authority
-        url: /government/collections/coronavirus-cases-by-local-authority-epidemiological-data
+      - label: An interactive map of coronavirus (COVID-19) cases in the UK
+        url: https://coronavirus.data.gov.uk/details/interactive-map
   topic_section:
     header: "All coronavirus information on GOV.UK"
     links:


### PR DESCRIPTION
Replacing the Coronavirus cases by local authority link to https://coronavirus.data.gov.uk/details/interactive-map as the original link has been withdrawn.

:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

# What
<!-- eg Changes to accordion links on the Coronavirus business page -->

# Why
<!-- eg Request from BEIS -->
