### PR TITLE
Revert "September 14th 2021 landing page header changes"

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -5,10 +5,12 @@ content:
   header_section:
     title: "Coronavirus remains a serious health risk. You should stay cautious to help protect yourself and others."
     intro: |
-      - Let fresh air in if you meet indoors. Meeting outdoors is safer
-      - Wear a face covering in crowded and enclosed spaces where you come into contact with people you do not normally meet
-      - [Get tested](https://www.nhs.uk/conditions/coronavirus-covid-19/testing/get-tested-for-coronavirus/) and self-isolate if required
-      - If you haven't already, [get vaccinated](https://www.nhs.uk/conditions/coronavirus-covid-19/coronavirus-vaccination/)
+      - Meet outside, or open windows and doors for indoor visitors
+      - If you think you have symptoms stay at home and [take a PCR test](/get-coronavirus-test)
+      - Wear face coverings in crowded places and on public transport
+      - Check in to venues when you go out
+      - Wash your hands with soap regularly, and for at least 20 seconds
+      - [Get vaccinated](https://www.nhs.uk/conditions/coronavirus-covid-19/coronavirus-vaccination/) 
     link:
       href: /guidance/covid-19-coronavirus-restrictions-what-you-can-and-cannot-do
       link_text: Find out how to stay safe and help


### PR DESCRIPTION
# What's changed?
Reverts alphagov/govuk-coronavirus-content#613

# Why?
The update has been delayed and this content blocks other landing page changes.