### PR TITLE
September 14th 2021 landing page header changes

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -5,12 +5,10 @@ content:
   header_section:
     title: "Coronavirus remains a serious health risk. You should stay cautious to help protect yourself and others."
     intro: |
-      - Meet outside, or open windows and doors for indoor visitors
-      - If you think you have symptoms stay at home and [take a PCR test](/get-coronavirus-test)
-      - Wear face coverings in crowded places and on public transport
-      - Check in to venues when you go out
-      - Wash your hands with soap regularly, and for at least 20 seconds
-      - [Get vaccinated](https://www.nhs.uk/conditions/coronavirus-covid-19/coronavirus-vaccination/) 
+      - Let fresh air in if you meet indoors. Meeting outdoors is safer
+      - Wear a face covering in crowded and enclosed spaces where you come into contact with people you do not normally meet
+      - [Get tested](https://www.nhs.uk/conditions/coronavirus-covid-19/testing/get-tested-for-coronavirus/) and self-isolate if required
+      - If you haven't already, [get vaccinated](https://www.nhs.uk/conditions/coronavirus-covid-19/coronavirus-vaccination/)
     link:
       href: /guidance/covid-19-coronavirus-restrictions-what-you-can-and-cannot-do
       link_text: Find out how to stay safe and help


### PR DESCRIPTION
Trello: https://trello.com/c/7zGu1Evn/1648-brief-devs-on-header-update

# What?
The bullet points on the coronavirus header need to be replaced (lines 7-13 in GitHub https://github.com/alphagov/govuk-coronavirus-content/blob/master/content/coronavirus_landing_page.yml).

The introductory text (h2) and jarrow link can remain the same.

There are two urls included. Both are external links.

The content has been approved and cleared by Cabinet Office.

# When?
We expect this will need to go live at 15:30 on Tuesday 14 September. This may change.

We must wait for the green light from Cabinet Office before we publish.
Header text markup
* Let fresh air in if you meet indoors. Meeting outdoors is safer
* Wear a face covering in crowded and enclosed spaces where you come into contact with people you do not normally meet
* [Get tested](https://www.nhs.uk/conditions/coronavirus-covid-19/testing/get-tested-for-coronavirus/) and self-isolate if required
* If you haven't already, [get vaccinated](https://www.nhs.uk/conditions/coronavirus-covid-19/coronavirus-vaccination/)

:warning: Only merge this pull request if you are happy for the changes to be made live :warning:
