### PR TITLE
Removing 'cases by local authority' link

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -86,8 +86,6 @@ content:
         url: https://www.ons.gov.uk/peoplepopulationandcommunity/healthandsocialcare/conditionsanddiseases
       - label: All data and analysis on coronavirus
         url: /guidance/coronavirus-covid-19-statistics-and-analysis
-      - label: Coronavirus cases by local authority
-        url: /government/collections/coronavirus-cases-by-local-authority-epidemiological-data
   topic_section:
     header: "All coronavirus information on GOV.UK"
     links:


### PR DESCRIPTION
Deleted the 'cases by local authority' link in stats because it has been withdrawn by data.gov

:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

# What
<!-- eg Changes to accordion links on the Coronavirus business page -->

# Why
<!-- eg Request from BEIS -->
