### PR TITLE
Add text for NHS section header

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -31,6 +31,7 @@ content:
       href: /risk-level
       text: Read more about COVID-19 alert levels
   nhs_banner:
+    header: Testing for coronavirus (COVID-19)
     sections:
       - heading: "If you have no symptoms:"
         markdown: |


### PR DESCRIPTION
:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

# What
Adds a heading for the new NHS section. This is part of the change of layout for the landing page, the NHS box will become a section and require this new heading.

# Why
Landing page design layout change.

Trello card: https://trello.com/c/IdVDZamX/41-adapt-landing-page-desktop-layout-to-show-h2s-in-the-left-hand-column
