### PR TITLE
Restructure text for doses

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -78,8 +78,12 @@ content:
         url: https://coronavirus.data.gov.uk/details/healthcare
     vaccinations:
       title: People vaccinated, and percent of population aged 12 and over vaccinated
-      first_dose_heading: 1st dose
-      second_dose_heading: 2nd dose
+      first_dose:
+        heading: 1st dose
+        label: people
+      second_dose:
+        heading: 2nd dose
+        label: people
       guidance_link:
         label: View all vaccination data on the coronavirus data dashboard
         url: https://coronavirus.data.gov.uk/details/vaccinations


### PR DESCRIPTION
:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

# What

- add 'people' text
- restructure into heading and label

Follows on from changes made in https://github.com/alphagov/govuk-coronavirus-content/pull/623

# Why

Overlooked in the previous change.

Trello card: https://trello.com/c/EM3HJ1RV/85-implement-coronavirus-statistics-iteration