### PR TITLE
[DO NOT MERGE] Remove header section data from YAML

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -2,17 +2,7 @@ content:
   title: "Coronavirus (COVID-19): guidance and support"
   meta_description: "Find information on coronavirus, including guidance, support, announcements and statistics."
   page_header: "Coronavirus (COVID&#8209;19)"
-  header_section:
-    title: "Coronavirus remains a serious health risk. You should stay cautious to help protect yourself and others."
-    intro: |
-      - Let fresh air in if you meet indoors. Meeting outdoors is safer
-      - Wear a face covering in crowded and enclosed spaces where you come into contact with people you do not normally meet
-      - [Get tested](https://www.nhs.uk/conditions/coronavirus-covid-19/testing/get-tested-for-coronavirus/) and self-isolate if required
-      - If you haven't already, [get vaccinated](https://www.nhs.uk/conditions/coronavirus-covid-19/coronavirus-vaccination/)
-    link:
-      href: /guidance/covid-19-coronavirus-restrictions-what-you-can-and-cannot-do
-      link_text: Find out how to stay safe and help
-      link_nowrap_text: prevent the spread
+  # The header section is edited in https://collections-publisher.publishing.service.gov.uk/coronavirus/landing
   announcements_label: Announcements
   # Announcements are edited in https://collections-publisher.publishing.service.gov.uk/coronavirus/landing
   announcements:

--- a/schema/coronavirus_landing_page.jsonnet
+++ b/schema/coronavirus_landing_page.jsonnet
@@ -7,7 +7,6 @@
       required: [
         'title',
         'meta_description',
-        'header_section',
         'announcements_label',
         'announcements',
         'nhs_banner',


### PR DESCRIPTION
DO NOT MERGE until after functionality to make the header section editable in Collections Publisher has been deployed. 

[Trello](https://trello.com/c/8dA4EoMU/317-remove-headersection-from-govuk-coronavirus-content-yml)

The header section can now be edited within [Collections Publisher](https://collections-publisher.publishing.service.gov.uk/coronavirus/landing/edit-header).

Therefore, the header section no longer needs to be edited within the
coronavirus_landing_page.yml file. Hence removing the header_section data.

:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

