### PR TITLE
[DO NOT MERGE] Remove old statistics content and keys

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -72,24 +72,6 @@ content:
         label: All vaccination data
         url: https://coronavirus.data.gov.uk/details/vaccinations
     updated_date: Latest data provided on
-    cumulative_vaccinations:
-      title: Total vaccinations
-      statistic_meaning: people have received their first dose
-      guidance_link:
-        label: Vaccination data from the coronavirus data dashboard
-        url: https://coronavirus.data.gov.uk/details/vaccinations
-    hospital_admissions:
-      title: Daily hospital admissions
-      statistic_meaning: new patients have been admitted to hospital
-      guidance_link:
-        label: Healthcare data from the coronavirus data dashboard
-        url: https://coronavirus.data.gov.uk/details/healthcare
-    new_positive_tests:
-      title: Daily new cases
-      statistic_meaning: people tested positive with COVID-19
-      guidance_link:
-        label: Cases data from the coronavirus data dashboard
-        url: https://coronavirus.data.gov.uk/details/cases
     links:
       - label: Daily summary of coronavirus testing, cases and vaccinations
         url: https://coronavirus.data.gov.uk/


### PR DESCRIPTION
Trello: https://trello.com/c/EM3HJ1RV
Depends on: https://github.com/alphagov/collections/pull/2576

# What's changed?
Removes old statistics content and keys.

# Why?
The statistics section has been revamped with new content and new keys.
This content is no longer needed.

:warning: Only merge this pull request if you are happy for the changes to be made live :warning: