### PR TITLE
Remove test yaml

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -27,14 +27,7 @@ content:
         markdown: "Find out how to get tested, what your test result means and how to report your result."
       - heading: "COVID-19 vaccination"
         url: "https://www.nhs.uk/conditions/coronavirus-covid-19/coronavirus-vaccination/"
-        markdown: "Get your COVID-19 vaccination including booster dose, read about how vaccinations work and what happens when you have one."
-    # nhs_sections is currently being used for test purposes, do not edit this. To edit nhs banner use the sections yaml above. 
-    nhs_sections: |
-      [Testing for COVID-19](https://www.nhs.uk/conditions/coronavirus-covid-19/testing/)
-      Find out how to get tested, what your test result means and how to report your result.
-
-      [COVID-19 vaccination](https://www.nhs.uk/conditions/coronavirus-covid-19/coronavirus-vaccination/)
-      Get your COVID-19 vaccination including booster dose, read about how vaccinations work and what happens when you have one.    
+        markdown: "Get your COVID-19 vaccination including booster dose, read about how vaccinations work and what happens when you have one."   
   # Timeline entries are edited in https://collections-publisher.publishing.service.gov.uk/coronavirus/landing
   timeline:
     heading: Recent and upcoming changes


### PR DESCRIPTION
Remove's the nhs_section yml added as part of a test into whether markdown could be rendered via yaml. The related Trello card is [here](https://trello.com/c/Bbyrgu9l/380-replace-the-nhs-sections-fields-with-a-markdown-field-in-the-govuk-coronavirus-content-yaml-file). 