### PR TITLE
Remove NHS box banner

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -19,15 +19,6 @@ content:
     link:
       href: /risk-level
       text: Read more about COVID-19 alert levels
-  nhs_banner:
-    header: Testing and vaccinations
-    sections:
-      - heading: "Testing for COVID-19"
-        url: "https://www.nhs.uk/conditions/coronavirus-covid-19/testing/"
-        markdown: "Find out how to get tested, what your test result means and how to report your result."
-      - heading: "COVID-19 vaccination"
-        url: "https://www.nhs.uk/conditions/coronavirus-covid-19/coronavirus-vaccination/"
-        markdown: "Get your COVID-19 vaccination including booster dose, read about how vaccinations work and what happens when you have one."   
   # Timeline entries are edited in https://collections-publisher.publishing.service.gov.uk/coronavirus/landing
   timeline:
     heading: Recent and upcoming changes
@@ -68,7 +59,7 @@ content:
       second_dose:
         heading: Second dose
         label: people
-      third_dose: 
+      third_dose:
         heading: Booster or third dose
         label: people
       guidance_link:

--- a/schema/coronavirus_landing_page.jsonnet
+++ b/schema/coronavirus_landing_page.jsonnet
@@ -8,7 +8,6 @@
         'title',
         'meta_description',
         'announcements_label',
-        'nhs_banner',
         'topic_section',
         'notifications'
       ]


### PR DESCRIPTION
## What

Remove `nhs_banner`

## Why

On [1st April - Remove NHS Box, Announcements, Timeline Entries, Statistics sections from landing page and move DA Links](https://trello.com/c/zxAAM52Y) we stopped rendering the NHS box on the landing page.

[Trello](https://trello.com/c/vn3rFVge/814-remove-nhs-box-from-yaml-file-and-as-required-for-publishing-in-collections-publisher)

:warning: Only merge this pull request if you are happy for the changes to be made live :warning:
