### PR TITLE
Remove announcements

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -1,24 +1,8 @@
 content:
   title: "Coronavirus (COVID-19): guidance and support"
-  meta_description: "Find information on coronavirus, including guidance, support, announcements and statistics."
+  meta_description: "Find information on coronavirus, including guidance, support and statistics."
   page_header: "Coronavirus (COVID&#8209;19)"
   # The header section is edited in https://collections-publisher.publishing.service.gov.uk/coronavirus/landing
-  announcements_label: Announcements
-  # Announcements are edited in https://collections-publisher.publishing.service.gov.uk/coronavirus/landing
-  see_all_announcements_link:
-    text: See all announcements
-    href: "/search/all?level_one_taxon=5b7b9532-a775-4bd2-a3aa-6ce380184b6c&content_purpose_supergroup%5B%5D=news_and_communications&order=updated-newest"
-  risk_level:
-    #set show_risk_level_section to true to display the risk/alert level section on the landing page
-    show_risk_level_section: false
-    heading: COVID-19 alert level
-    paragraph: Level X of 5 – there is something happening
-    # bold_text should be the portion of the paragraph you would like to make bold.
-    # for instance, if our paragraph is "Find information on coronavirus", and we want the word "coronavirus" to be bold, we would set bold_text: coronavirus
-    bold_text: Level X of 5
-    link:
-      href: /risk-level
-      text: Read more about COVID-19 alert levels
   # Timeline entries are edited in https://collections-publisher.publishing.service.gov.uk/coronavirus/landing
   timeline:
     heading: Recent and upcoming changes

--- a/schema/coronavirus_landing_page.jsonnet
+++ b/schema/coronavirus_landing_page.jsonnet
@@ -7,7 +7,6 @@
       required: [
         'title',
         'meta_description',
-        'announcements_label',
         'topic_section',
         'notifications'
       ]


### PR DESCRIPTION
## What

Remove announcements

## Why

In [1st April - Remove NHS Box, Announcements, Timeline Entries, Statistics sections from landing page and move DA Links](https://trello.com/c/zxAAM52Y) we stopped rendering the announcements section on the landing page. Now we need to remove the publishing code.

The risk level content is being hidden, but it used to be rendered as part of the announcements section and can also be removed.

[Trello](https://trello.com/c/JyDtH6Dr/815-remove-announcements-section-from-collections-publisher-and-yaml-file)

:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

