### PR TITLE
Remove timeline

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -3,9 +3,6 @@ content:
   meta_description: "Find information on coronavirus, including guidance and support."
   page_header: "Coronavirus (COVID&#8209;19)"
   # The header section is edited in https://collections-publisher.publishing.service.gov.uk/coronavirus/landing
-  # Timeline entries are edited in https://collections-publisher.publishing.service.gov.uk/coronavirus/landing
-  timeline:
-    heading: Recent and upcoming changes
   sections_heading: "Guidance and support"
   # sections are edited in https://collections-publisher.publishing.service.gov.uk/coronavirus/landing
   additional_country_guidance:


### PR DESCRIPTION
## What

Remove timeline

## Why

In [1st April - Remove NHS Box, Announcements, Timeline Entries, Statistics sections from landing page and move DA Links](https://trello.com/c/zxAAM52Y) we stopped rendering the timeline section on the landing page. Now we need to remove the publishing code.

The risk level content is being hidden, but it used to be rendered as part of the timeline section and can also be removed.

[Trello](https://trello.com/c/Nf14aso0/816-remove-timeline-entries-section-from-collections-publisher-and-yaml-file)

:warning: Only merge this pull request if you are happy for the changes to be made live :warning:
