### PR TITLE
Remove statistics section yaml

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -1,6 +1,6 @@
 content:
   title: "Coronavirus (COVID-19): guidance and support"
-  meta_description: "Find information on coronavirus, including guidance, support and statistics."
+  meta_description: "Find information on coronavirus, including guidance and support."
   page_header: "Coronavirus (COVID&#8209;19)"
   # The header section is edited in https://collections-publisher.publishing.service.gov.uk/coronavirus/landing
   # Timeline entries are edited in https://collections-publisher.publishing.service.gov.uk/coronavirus/landing
@@ -19,44 +19,6 @@ content:
         url: https://gov.wales/coronavirus
       - label: "Guidance for Northern Ireland"
         url: https://www.nidirect.gov.uk/campaigns/coronavirus-covid-19
-  statistics_section:
-    header: UK COVID-19 statistics
-    tests:
-      title: People tested positive
-      daily_heading: Daily
-      weekly_heading: Last 7 days
-      guidance_link:
-        label: All case data
-        url: https://coronavirus.data.gov.uk/details/cases
-    admissions:
-      title: Patients admitted to hospital
-      daily_heading: Daily
-      weekly_heading: Last 7 days
-      guidance_link:
-        label: All healthcare data
-        url: https://coronavirus.data.gov.uk/details/healthcare
-    vaccinations:
-      title: People vaccinated, percentage of population aged 12 and over
-      first_dose:
-        heading: First dose
-        label: people
-      second_dose:
-        heading: Second dose
-        label: people
-      third_dose:
-        heading: Booster or third dose
-        label: people
-      guidance_link:
-        label: All vaccination data
-        url: https://coronavirus.data.gov.uk/details/vaccinations
-    updated_date: Latest data provided on
-    links:
-      - label: Daily summary of COVID-19 testing, cases and vaccinations
-        url: https://coronavirus.data.gov.uk/
-      - label: Data and trends from the Office for National Statistics (ONS)
-        url: https://www.ons.gov.uk/peoplepopulationandcommunity/healthandsocialcare/conditionsanddiseases
-      - label: All data and analysis on COVID-19
-        url: /guidance/coronavirus-covid-19-statistics-and-analysis
   topic_section:
     header: "More COVID-19 information"
     links:


### PR DESCRIPTION
:warning: Only merge this pull request if you are happy for the changes to be made live :warning:

# What
Remove statistics section

# Why
In [1st April - Remove NHS Box, Announcements, Timeline Entries, Statistics sections from landing page and move DA Links](https://trello.com/c/zxAAM52Y) we stopped rendering the statistics section on the landing page. Now we need to remove the publishing code.

[Trello](https://trello.com/c/82XTs501/813-remove-statistics-section-from-yaml-file)