### PR TITLE
Update text on the stats page link

### DIFF
--- a/content/coronavirus_landing_page.yml
+++ b/content/coronavirus_landing_page.yml
@@ -29,7 +29,7 @@ content:
         url: "/search/all?level_one_taxon=5b7b9532-a775-4bd2-a3aa-6ce380184b6c&content_purpose_supergroup%5B%5D=policy_and_engagement&order=updated-newest"
       - label: "Transparency and freedom of information releases about COVID-19"
         url: "/search/all?level_one_taxon=5b7b9532-a775-4bd2-a3aa-6ce380184b6c&content_purpose_supergroup%5B%5D=transparency&order=updated-newest"
-      - label: "Summary of COVID-19 testing, cases and vaccinations"
+      - label: "Summary of COVID-19 testing, cases and vaccinations data"
         url: "https://coronavirus.data.gov.uk/"
       - label: "COVID-19 legislation on legislation.gov.uk"
         url: "https://www.legislation.gov.uk/coronavirus"


### PR DESCRIPTION
[Trello](https://trello.com/c/JTVY5XIO/848-change-text-of-stats-link-in-more-covid-info)

To make sure that users can find the statistics link, now that the stats section has been retired.


