### PR TITLE
Update README to explain that this repo is Archived

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# Archived: This project is not in use 
+
+The remaining content in [content/coronavirus_landing_page.yml](https://github.com/alphagov/govuk-coronavirus-content/blob/master/content/coronavirus_landing_page.yml) has been moved into [the rendering application](https://github.com/alphagov/collections/pull/2748).
+
 # govuk-coronavirus-content
 
 Stores the content for the following pages:


### PR DESCRIPTION
[Trello](https://trello.com/c/ZmKgV2Xm/846-archive-govuk-coronavirus-content)

This repository is being archived. The amount of content on the /coronavirus landing page was reduced due to the ending of COVID restrictions in England. 
 
The future format of the /coronavirus page is being decided, but it is likely that it will not be a page published from Collections Publisher for much longer. 

As a result we are archiving this repository. Having one less repo will make /coronavirus easier to maintain. This also allowed us to [remove govuk-coronavirus-content related code from Collections Publisher](https://github.com/alphagov/collections-publisher/pull/1574). This makes Collections Publisher easier to maintain. 

Given that there wasn't much content left in this repo, it has been [hard-coded into the rendering application](https://github.com/alphagov/collections/pull/2748). The downside of this is that Content Designers will no longer be able to update this content. It will require a developer to make the changes directly in Collections. Fortunately, this content is not updated very often.

